### PR TITLE
Add thread safety to olink connection

### DIFF
--- a/goldenmaster/apigear/olink/olinkconnection.h
+++ b/goldenmaster/apigear/olink/olinkconnection.h
@@ -27,6 +27,7 @@
 
 #include <atomic>
 #include <queue>
+#include <deque>
 #include <set>
 #include <memory>
 #include <future>
@@ -104,8 +105,10 @@ private:
     * @param task. Parameter is not used. The function uses most recent task stored as a member.
     */
     void processMessages(Poco::Util::TimerTask& task);
-    /** Schedules a process messages task.*/
-    void scheduleProcessMessages();
+    /** Schedules a process messages task.
+        @param delayMiliseconds. A delay with which task is scheduled.
+    */
+    void scheduleProcessMessages(long delayMiliseconds);
 
     /** Finalize close connection. */
     void cleanupConnectionResources();
@@ -133,8 +136,10 @@ private:
     Poco::Util::Timer m_retryTimer;
     /** Poco Task that handles processing messages */
     Poco::Util::TimerTask::Ptr m_processMessagesTask;
+    /** A mutex for the process messages task */
+    std::timed_mutex m_taskMutex;
     /** Messages queue, store messages to send also before the connection is set. */
-    std::queue<std::string> m_queue;
+    std::deque<std::string> m_queue;
     /** A mutex for the message queue */
     std::timed_mutex m_queueMutex;
     /** Flag handled between the threads with information that the connection should be closed. */

--- a/templates/apigear/olink/olinkconnection.h
+++ b/templates/apigear/olink/olinkconnection.h
@@ -27,6 +27,7 @@
 
 #include <atomic>
 #include <queue>
+#include <deque>
 #include <set>
 #include <memory>
 #include <future>
@@ -104,8 +105,10 @@ private:
     * @param task. Parameter is not used. The function uses most recent task stored as a member.
     */
     void processMessages(Poco::Util::TimerTask& task);
-    /** Schedules a process messages task.*/
-    void scheduleProcessMessages();
+    /** Schedules a process messages task.
+        @param delayMiliseconds. A delay with which task is scheduled.
+    */
+    void scheduleProcessMessages(long delayMiliseconds);
 
     /** Finalize close connection. */
     void cleanupConnectionResources();
@@ -133,8 +136,10 @@ private:
     Poco::Util::Timer m_retryTimer;
     /** Poco Task that handles processing messages */
     Poco::Util::TimerTask::Ptr m_processMessagesTask;
+    /** A mutex for the process messages task */
+    std::timed_mutex m_taskMutex;
     /** Messages queue, store messages to send also before the connection is set. */
-    std::queue<std::string> m_queue;
+    std::deque<std::string> m_queue;
     /** A mutex for the message queue */
     std::timed_mutex m_queueMutex;
     /** Flag handled between the threads with information that the connection should be closed. */


### PR DESCRIPTION
Introduces locks for socket and a scheduled task. Reworks sending messages to avoid locking message queue and socket in one time.