### PR TITLE
perf: optimize use of createMemberId

### DIFF
--- a/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceclient.cpp
+++ b/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_enum/generated/core/tb_enum.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbEnum;
@@ -42,7 +41,7 @@ void EnumInterfaceClient::setProp0(Enum0Enum prop0)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop0");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop0");
     m_node->setRemoteProperty(propertyId, prop0);
 }
 
@@ -65,7 +64,7 @@ void EnumInterfaceClient::setProp1(Enum1Enum prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -88,7 +87,7 @@ void EnumInterfaceClient::setProp2(Enum2Enum prop2)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
     m_node->setRemoteProperty(propertyId, prop2);
 }
 
@@ -111,7 +110,7 @@ void EnumInterfaceClient::setProp3(Enum3Enum prop3)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
     m_node->setRemoteProperty(propertyId, prop3);
 }
 
@@ -148,7 +147,7 @@ std::future<Enum0Enum> EnumInterfaceClient::func0Async(Enum0Enum param0)
                     param0]()
         {
             std::promise<Enum0Enum> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func0");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func0");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param0}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Enum0Enum& value = arg.value.get<Enum0Enum>();
@@ -179,7 +178,7 @@ std::future<Enum1Enum> EnumInterfaceClient::func1Async(Enum1Enum param1)
                     param1]()
         {
             std::promise<Enum1Enum> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Enum1Enum& value = arg.value.get<Enum1Enum>();
@@ -210,7 +209,7 @@ std::future<Enum2Enum> EnumInterfaceClient::func2Async(Enum2Enum param2)
                     param2]()
         {
             std::promise<Enum2Enum> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Enum2Enum& value = arg.value.get<Enum2Enum>();
@@ -241,7 +240,7 @@ std::future<Enum3Enum> EnumInterfaceClient::func3Async(Enum3Enum param3)
                     param3]()
         {
             std::promise<Enum3Enum> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func3");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func3");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param3}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Enum3Enum& value = arg.value.get<Enum3Enum>();

--- a/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceclient.h
+++ b/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_enum/generated/api/tb_enum.h"
 #include "tb_enum/generated/core/enuminterface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceservice.cpp
+++ b/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceservice.cpp
@@ -102,8 +102,9 @@ nlohmann::json EnumInterfaceService::olinkCollectProperties()
 void EnumInterfaceService::onSig0(Enum0Enum param0)
 {
     const nlohmann::json args = { param0 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig0");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig0");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -113,8 +114,9 @@ void EnumInterfaceService::onSig0(Enum0Enum param0)
 void EnumInterfaceService::onSig1(Enum1Enum param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -124,8 +126,9 @@ void EnumInterfaceService::onSig1(Enum1Enum param1)
 void EnumInterfaceService::onSig2(Enum2Enum param2)
 {
     const nlohmann::json args = { param2 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -135,8 +138,9 @@ void EnumInterfaceService::onSig2(Enum2Enum param2)
 void EnumInterfaceService::onSig3(Enum3Enum param3)
 {
     const nlohmann::json args = { param3 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig3");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig3");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -145,8 +149,9 @@ void EnumInterfaceService::onSig3(Enum3Enum param3)
 }
 void EnumInterfaceService::onProp0Changed(Enum0Enum prop0)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop0");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop0");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop0);
@@ -155,8 +160,9 @@ void EnumInterfaceService::onProp0Changed(Enum0Enum prop0)
 }
 void EnumInterfaceService::onProp1Changed(Enum1Enum prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);
@@ -165,8 +171,9 @@ void EnumInterfaceService::onProp1Changed(Enum1Enum prop1)
 }
 void EnumInterfaceService::onProp2Changed(Enum2Enum prop2)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop2);
@@ -175,8 +182,9 @@ void EnumInterfaceService::onProp2Changed(Enum2Enum prop2)
 }
 void EnumInterfaceService::onProp3Changed(Enum3Enum prop3)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop3);

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum1interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum1interfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_same1/generated/core/tb_same1.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame1;
@@ -33,7 +32,7 @@ void SameEnum1InterfaceClient::setProp1(Enum1Enum prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -70,7 +69,7 @@ std::future<Enum1Enum> SameEnum1InterfaceClient::func1Async(Enum1Enum param1)
                     param1]()
         {
             std::promise<Enum1Enum> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Enum1Enum& value = arg.value.get<Enum1Enum>();

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum1interfaceclient.h
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum1interfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_same1/generated/api/tb_same1.h"
 #include "tb_same1/generated/core/sameenum1interface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum1interfaceservice.cpp
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum1interfaceservice.cpp
@@ -72,8 +72,9 @@ nlohmann::json SameEnum1InterfaceService::olinkCollectProperties()
 void SameEnum1InterfaceService::onSig1(Enum1Enum param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -82,8 +83,9 @@ void SameEnum1InterfaceService::onSig1(Enum1Enum param1)
 }
 void SameEnum1InterfaceService::onProp1Changed(Enum1Enum prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum2interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum2interfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_same1/generated/core/tb_same1.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame1;
@@ -36,7 +35,7 @@ void SameEnum2InterfaceClient::setProp1(Enum1Enum prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -59,7 +58,7 @@ void SameEnum2InterfaceClient::setProp2(Enum2Enum prop2)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
     m_node->setRemoteProperty(propertyId, prop2);
 }
 
@@ -96,7 +95,7 @@ std::future<Enum1Enum> SameEnum2InterfaceClient::func1Async(Enum1Enum param1)
                     param1]()
         {
             std::promise<Enum1Enum> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Enum1Enum& value = arg.value.get<Enum1Enum>();
@@ -128,7 +127,7 @@ std::future<Enum1Enum> SameEnum2InterfaceClient::func2Async(Enum1Enum param1, En
                     param2]()
         {
             std::promise<Enum1Enum> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Enum1Enum& value = arg.value.get<Enum1Enum>();

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum2interfaceclient.h
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum2interfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_same1/generated/api/tb_same1.h"
 #include "tb_same1/generated/core/sameenum2interface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum2interfaceservice.cpp
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum2interfaceservice.cpp
@@ -83,8 +83,9 @@ nlohmann::json SameEnum2InterfaceService::olinkCollectProperties()
 void SameEnum2InterfaceService::onSig1(Enum1Enum param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -94,8 +95,9 @@ void SameEnum2InterfaceService::onSig1(Enum1Enum param1)
 void SameEnum2InterfaceService::onSig2(Enum1Enum param1, Enum2Enum param2)
 {
     const nlohmann::json args = { param1, param2 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -104,8 +106,9 @@ void SameEnum2InterfaceService::onSig2(Enum1Enum param1, Enum2Enum param2)
 }
 void SameEnum2InterfaceService::onProp1Changed(Enum1Enum prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);
@@ -114,8 +117,9 @@ void SameEnum2InterfaceService::onProp1Changed(Enum1Enum prop1)
 }
 void SameEnum2InterfaceService::onProp2Changed(Enum2Enum prop2)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop2);

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_same1/generated/core/tb_same1.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame1;
@@ -33,7 +32,7 @@ void SameStruct1InterfaceClient::setProp1(const Struct1& prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -70,7 +69,7 @@ std::future<Struct1> SameStruct1InterfaceClient::func1Async(const Struct1& param
                     param1]()
         {
             std::promise<Struct1> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Struct1& value = arg.value.get<Struct1>();

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceclient.h
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_same1/generated/api/tb_same1.h"
 #include "tb_same1/generated/core/samestruct1interface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceservice.cpp
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceservice.cpp
@@ -72,8 +72,9 @@ nlohmann::json SameStruct1InterfaceService::olinkCollectProperties()
 void SameStruct1InterfaceService::onSig1(const Struct1& param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -82,8 +83,9 @@ void SameStruct1InterfaceService::onSig1(const Struct1& param1)
 }
 void SameStruct1InterfaceService::onProp1Changed(const Struct1& prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct2interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct2interfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_same1/generated/core/tb_same1.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame1;
@@ -36,7 +35,7 @@ void SameStruct2InterfaceClient::setProp1(const Struct2& prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -59,7 +58,7 @@ void SameStruct2InterfaceClient::setProp2(const Struct2& prop2)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
     m_node->setRemoteProperty(propertyId, prop2);
 }
 
@@ -96,7 +95,7 @@ std::future<Struct1> SameStruct2InterfaceClient::func1Async(const Struct1& param
                     param1]()
         {
             std::promise<Struct1> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Struct1& value = arg.value.get<Struct1>();
@@ -128,7 +127,7 @@ std::future<Struct1> SameStruct2InterfaceClient::func2Async(const Struct1& param
                     param2]()
         {
             std::promise<Struct1> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Struct1& value = arg.value.get<Struct1>();

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct2interfaceclient.h
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct2interfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_same1/generated/api/tb_same1.h"
 #include "tb_same1/generated/core/samestruct2interface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct2interfaceservice.cpp
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct2interfaceservice.cpp
@@ -83,8 +83,9 @@ nlohmann::json SameStruct2InterfaceService::olinkCollectProperties()
 void SameStruct2InterfaceService::onSig1(const Struct1& param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -94,8 +95,9 @@ void SameStruct2InterfaceService::onSig1(const Struct1& param1)
 void SameStruct2InterfaceService::onSig2(const Struct1& param1, const Struct2& param2)
 {
     const nlohmann::json args = { param1, param2 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -104,8 +106,9 @@ void SameStruct2InterfaceService::onSig2(const Struct1& param1, const Struct2& p
 }
 void SameStruct2InterfaceService::onProp1Changed(const Struct2& prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);
@@ -114,8 +117,9 @@ void SameStruct2InterfaceService::onProp1Changed(const Struct2& prop1)
 }
 void SameStruct2InterfaceService::onProp2Changed(const Struct2& prop2)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop2);

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum1interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum1interfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_same2/generated/core/tb_same2.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame2;
@@ -33,7 +32,7 @@ void SameEnum1InterfaceClient::setProp1(Enum1Enum prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -70,7 +69,7 @@ std::future<Enum1Enum> SameEnum1InterfaceClient::func1Async(Enum1Enum param1)
                     param1]()
         {
             std::promise<Enum1Enum> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Enum1Enum& value = arg.value.get<Enum1Enum>();

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum1interfaceclient.h
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum1interfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_same2/generated/api/tb_same2.h"
 #include "tb_same2/generated/core/sameenum1interface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum1interfaceservice.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum1interfaceservice.cpp
@@ -72,8 +72,9 @@ nlohmann::json SameEnum1InterfaceService::olinkCollectProperties()
 void SameEnum1InterfaceService::onSig1(Enum1Enum param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -82,8 +83,9 @@ void SameEnum1InterfaceService::onSig1(Enum1Enum param1)
 }
 void SameEnum1InterfaceService::onProp1Changed(Enum1Enum prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum2interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum2interfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_same2/generated/core/tb_same2.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame2;
@@ -36,7 +35,7 @@ void SameEnum2InterfaceClient::setProp1(Enum1Enum prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -59,7 +58,7 @@ void SameEnum2InterfaceClient::setProp2(Enum2Enum prop2)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
     m_node->setRemoteProperty(propertyId, prop2);
 }
 
@@ -96,7 +95,7 @@ std::future<Enum1Enum> SameEnum2InterfaceClient::func1Async(Enum1Enum param1)
                     param1]()
         {
             std::promise<Enum1Enum> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Enum1Enum& value = arg.value.get<Enum1Enum>();
@@ -128,7 +127,7 @@ std::future<Enum1Enum> SameEnum2InterfaceClient::func2Async(Enum1Enum param1, En
                     param2]()
         {
             std::promise<Enum1Enum> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Enum1Enum& value = arg.value.get<Enum1Enum>();

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum2interfaceclient.h
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum2interfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_same2/generated/api/tb_same2.h"
 #include "tb_same2/generated/core/sameenum2interface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum2interfaceservice.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum2interfaceservice.cpp
@@ -83,8 +83,9 @@ nlohmann::json SameEnum2InterfaceService::olinkCollectProperties()
 void SameEnum2InterfaceService::onSig1(Enum1Enum param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -94,8 +95,9 @@ void SameEnum2InterfaceService::onSig1(Enum1Enum param1)
 void SameEnum2InterfaceService::onSig2(Enum1Enum param1, Enum2Enum param2)
 {
     const nlohmann::json args = { param1, param2 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -104,8 +106,9 @@ void SameEnum2InterfaceService::onSig2(Enum1Enum param1, Enum2Enum param2)
 }
 void SameEnum2InterfaceService::onProp1Changed(Enum1Enum prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);
@@ -114,8 +117,9 @@ void SameEnum2InterfaceService::onProp1Changed(Enum1Enum prop1)
 }
 void SameEnum2InterfaceService::onProp2Changed(Enum2Enum prop2)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop2);

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_same2/generated/core/tb_same2.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame2;
@@ -33,7 +32,7 @@ void SameStruct1InterfaceClient::setProp1(const Struct1& prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -70,7 +69,7 @@ std::future<Struct1> SameStruct1InterfaceClient::func1Async(const Struct1& param
                     param1]()
         {
             std::promise<Struct1> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Struct1& value = arg.value.get<Struct1>();

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceclient.h
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_same2/generated/api/tb_same2.h"
 #include "tb_same2/generated/core/samestruct1interface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceservice.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceservice.cpp
@@ -72,8 +72,9 @@ nlohmann::json SameStruct1InterfaceService::olinkCollectProperties()
 void SameStruct1InterfaceService::onSig1(const Struct1& param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -82,8 +83,9 @@ void SameStruct1InterfaceService::onSig1(const Struct1& param1)
 }
 void SameStruct1InterfaceService::onProp1Changed(const Struct1& prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct2interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct2interfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_same2/generated/core/tb_same2.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame2;
@@ -36,7 +35,7 @@ void SameStruct2InterfaceClient::setProp1(const Struct2& prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -59,7 +58,7 @@ void SameStruct2InterfaceClient::setProp2(const Struct2& prop2)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
     m_node->setRemoteProperty(propertyId, prop2);
 }
 
@@ -96,7 +95,7 @@ std::future<Struct1> SameStruct2InterfaceClient::func1Async(const Struct1& param
                     param1]()
         {
             std::promise<Struct1> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Struct1& value = arg.value.get<Struct1>();
@@ -128,7 +127,7 @@ std::future<Struct1> SameStruct2InterfaceClient::func2Async(const Struct1& param
                     param2]()
         {
             std::promise<Struct1> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const Struct1& value = arg.value.get<Struct1>();

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct2interfaceclient.h
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct2interfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_same2/generated/api/tb_same2.h"
 #include "tb_same2/generated/core/samestruct2interface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct2interfaceservice.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct2interfaceservice.cpp
@@ -83,8 +83,9 @@ nlohmann::json SameStruct2InterfaceService::olinkCollectProperties()
 void SameStruct2InterfaceService::onSig1(const Struct1& param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -94,8 +95,9 @@ void SameStruct2InterfaceService::onSig1(const Struct1& param1)
 void SameStruct2InterfaceService::onSig2(const Struct1& param1, const Struct2& param2)
 {
     const nlohmann::json args = { param1, param2 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -104,8 +106,9 @@ void SameStruct2InterfaceService::onSig2(const Struct1& param1, const Struct2& p
 }
 void SameStruct2InterfaceService::onProp1Changed(const Struct2& prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);
@@ -114,8 +117,9 @@ void SameStruct2InterfaceService::onProp1Changed(const Struct2& prop1)
 }
 void SameStruct2InterfaceService::onProp2Changed(const Struct2& prop2)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop2);

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nooperationsinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nooperationsinterfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_simple/generated/core/tb_simple.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSimple;
@@ -36,7 +35,7 @@ void NoOperationsInterfaceClient::setPropBool(bool propBool)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
     m_node->setRemoteProperty(propertyId, propBool);
 }
 
@@ -59,7 +58,7 @@ void NoOperationsInterfaceClient::setPropInt(int propInt)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
     m_node->setRemoteProperty(propertyId, propInt);
 }
 

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nooperationsinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nooperationsinterfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_simple/generated/api/tb_simple.h"
 #include "tb_simple/generated/core/nooperationsinterface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nooperationsinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nooperationsinterfaceservice.cpp
@@ -75,8 +75,9 @@ nlohmann::json NoOperationsInterfaceService::olinkCollectProperties()
 void NoOperationsInterfaceService::onSigVoid()
 {
     const nlohmann::json args = {  };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigVoid");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigVoid");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -86,8 +87,9 @@ void NoOperationsInterfaceService::onSigVoid()
 void NoOperationsInterfaceService::onSigBool(bool paramBool)
 {
     const nlohmann::json args = { paramBool };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -96,8 +98,9 @@ void NoOperationsInterfaceService::onSigBool(bool paramBool)
 }
 void NoOperationsInterfaceService::onPropBoolChanged(bool propBool)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propBool);
@@ -106,8 +109,9 @@ void NoOperationsInterfaceService::onPropBoolChanged(bool propBool)
 }
 void NoOperationsInterfaceService::onPropIntChanged(int propInt)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propInt);

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nopropertiesinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nopropertiesinterfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_simple/generated/core/tb_simple.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSimple;
@@ -37,7 +36,7 @@ void NoPropertiesInterfaceClient::funcVoid()
             (void) arg;
         };
     const nlohmann::json &args = nlohmann::json::array({  });
-    const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
     m_node->invokeRemote(operationId, args, func);
 }
 
@@ -50,7 +49,7 @@ std::future<void> NoPropertiesInterfaceClient::funcVoidAsync()
     return std::async(std::launch::async, [this]()
         {
             std::promise<void> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     (void) arg;
@@ -81,7 +80,7 @@ std::future<bool> NoPropertiesInterfaceClient::funcBoolAsync(bool paramBool)
                     paramBool]()
         {
             std::promise<bool> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramBool}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const bool& value = arg.value.get<bool>();

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nopropertiesinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nopropertiesinterfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_simple/generated/api/tb_simple.h"
 #include "tb_simple/generated/core/nopropertiesinterface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nopropertiesinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nopropertiesinterfaceservice.cpp
@@ -74,8 +74,9 @@ nlohmann::json NoPropertiesInterfaceService::olinkCollectProperties()
 void NoPropertiesInterfaceService::onSigVoid()
 {
     const nlohmann::json args = {  };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigVoid");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigVoid");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -85,8 +86,9 @@ void NoPropertiesInterfaceService::onSigVoid()
 void NoPropertiesInterfaceService::onSigBool(bool paramBool)
 {
     const nlohmann::json args = { paramBool };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nosignalsinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nosignalsinterfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_simple/generated/core/tb_simple.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSimple;
@@ -36,7 +35,7 @@ void NoSignalsInterfaceClient::setPropBool(bool propBool)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
     m_node->setRemoteProperty(propertyId, propBool);
 }
 
@@ -59,7 +58,7 @@ void NoSignalsInterfaceClient::setPropInt(int propInt)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
     m_node->setRemoteProperty(propertyId, propInt);
 }
 
@@ -88,7 +87,7 @@ void NoSignalsInterfaceClient::funcVoid()
             (void) arg;
         };
     const nlohmann::json &args = nlohmann::json::array({  });
-    const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
     m_node->invokeRemote(operationId, args, func);
 }
 
@@ -101,7 +100,7 @@ std::future<void> NoSignalsInterfaceClient::funcVoidAsync()
     return std::async(std::launch::async, [this]()
         {
             std::promise<void> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     (void) arg;
@@ -132,7 +131,7 @@ std::future<bool> NoSignalsInterfaceClient::funcBoolAsync(bool paramBool)
                     paramBool]()
         {
             std::promise<bool> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramBool}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const bool& value = arg.value.get<bool>();

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nosignalsinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nosignalsinterfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_simple/generated/api/tb_simple.h"
 #include "tb_simple/generated/core/nosignalsinterface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nosignalsinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nosignalsinterfaceservice.cpp
@@ -80,8 +80,9 @@ nlohmann::json NoSignalsInterfaceService::olinkCollectProperties()
 }
 void NoSignalsInterfaceService::onPropBoolChanged(bool propBool)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propBool);
@@ -90,8 +91,9 @@ void NoSignalsInterfaceService::onPropBoolChanged(bool propBool)
 }
 void NoSignalsInterfaceService::onPropIntChanged(int propInt)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propInt);

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_simple/generated/core/tb_simple.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSimple;
@@ -54,7 +53,7 @@ void SimpleArrayInterfaceClient::setPropBool(const std::list<bool>& propBool)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
     m_node->setRemoteProperty(propertyId, propBool);
 }
 
@@ -77,7 +76,7 @@ void SimpleArrayInterfaceClient::setPropInt(const std::list<int>& propInt)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
     m_node->setRemoteProperty(propertyId, propInt);
 }
 
@@ -100,7 +99,7 @@ void SimpleArrayInterfaceClient::setPropInt32(const std::list<int32_t>& propInt3
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt32");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt32");
     m_node->setRemoteProperty(propertyId, propInt32);
 }
 
@@ -123,7 +122,7 @@ void SimpleArrayInterfaceClient::setPropInt64(const std::list<int64_t>& propInt6
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt64");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt64");
     m_node->setRemoteProperty(propertyId, propInt64);
 }
 
@@ -146,7 +145,7 @@ void SimpleArrayInterfaceClient::setPropFloat(const std::list<float>& propFloat)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
     m_node->setRemoteProperty(propertyId, propFloat);
 }
 
@@ -169,7 +168,7 @@ void SimpleArrayInterfaceClient::setPropFloat32(const std::list<float>& propFloa
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat32");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat32");
     m_node->setRemoteProperty(propertyId, propFloat32);
 }
 
@@ -192,7 +191,7 @@ void SimpleArrayInterfaceClient::setPropFloat64(const std::list<double>& propFlo
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat64");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat64");
     m_node->setRemoteProperty(propertyId, propFloat64);
 }
 
@@ -215,7 +214,7 @@ void SimpleArrayInterfaceClient::setPropString(const std::list<std::string>& pro
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
     m_node->setRemoteProperty(propertyId, propString);
 }
 
@@ -252,7 +251,7 @@ std::future<std::list<bool>> SimpleArrayInterfaceClient::funcBoolAsync(const std
                     paramBool]()
         {
             std::promise<std::list<bool>> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramBool}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const std::list<bool>& value = arg.value.get<std::list<bool>>();
@@ -283,7 +282,7 @@ std::future<std::list<int>> SimpleArrayInterfaceClient::funcIntAsync(const std::
                     paramInt]()
         {
             std::promise<std::list<int>> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramInt}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const std::list<int>& value = arg.value.get<std::list<int>>();
@@ -314,7 +313,7 @@ std::future<std::list<int32_t>> SimpleArrayInterfaceClient::funcInt32Async(const
                     paramInt32]()
         {
             std::promise<std::list<int32_t>> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt32");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt32");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramInt32}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const std::list<int32_t>& value = arg.value.get<std::list<int32_t>>();
@@ -345,7 +344,7 @@ std::future<std::list<int64_t>> SimpleArrayInterfaceClient::funcInt64Async(const
                     paramInt64]()
         {
             std::promise<std::list<int64_t>> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt64");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt64");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramInt64}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const std::list<int64_t>& value = arg.value.get<std::list<int64_t>>();
@@ -376,7 +375,7 @@ std::future<std::list<float>> SimpleArrayInterfaceClient::funcFloatAsync(const s
                     paramFloat]()
         {
             std::promise<std::list<float>> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const std::list<float>& value = arg.value.get<std::list<float>>();
@@ -407,7 +406,7 @@ std::future<std::list<float>> SimpleArrayInterfaceClient::funcFloat32Async(const
                     paramFloat32]()
         {
             std::promise<std::list<float>> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat32");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat32");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramFloat32}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const std::list<float>& value = arg.value.get<std::list<float>>();
@@ -438,7 +437,7 @@ std::future<std::list<double>> SimpleArrayInterfaceClient::funcFloat64Async(cons
                     paramFloat]()
         {
             std::promise<std::list<double>> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat64");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat64");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const std::list<double>& value = arg.value.get<std::list<double>>();
@@ -469,7 +468,7 @@ std::future<std::list<std::string>> SimpleArrayInterfaceClient::funcStringAsync(
                     paramString]()
         {
             std::promise<std::list<std::string>> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramString}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const std::list<std::string>& value = arg.value.get<std::list<std::string>>();

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_simple/generated/api/tb_simple.h"
 #include "tb_simple/generated/core/simplearrayinterface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceservice.cpp
@@ -142,8 +142,9 @@ nlohmann::json SimpleArrayInterfaceService::olinkCollectProperties()
 void SimpleArrayInterfaceService::onSigBool(const std::list<bool>& paramBool)
 {
     const nlohmann::json args = { paramBool };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -153,8 +154,9 @@ void SimpleArrayInterfaceService::onSigBool(const std::list<bool>& paramBool)
 void SimpleArrayInterfaceService::onSigInt(const std::list<int>& paramInt)
 {
     const nlohmann::json args = { paramInt };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -164,8 +166,9 @@ void SimpleArrayInterfaceService::onSigInt(const std::list<int>& paramInt)
 void SimpleArrayInterfaceService::onSigInt32(const std::list<int32_t>& paramInt32)
 {
     const nlohmann::json args = { paramInt32 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt32");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt32");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -175,8 +178,9 @@ void SimpleArrayInterfaceService::onSigInt32(const std::list<int32_t>& paramInt3
 void SimpleArrayInterfaceService::onSigInt64(const std::list<int64_t>& paramInt64)
 {
     const nlohmann::json args = { paramInt64 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt64");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt64");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -186,8 +190,9 @@ void SimpleArrayInterfaceService::onSigInt64(const std::list<int64_t>& paramInt6
 void SimpleArrayInterfaceService::onSigFloat(const std::list<float>& paramFloat)
 {
     const nlohmann::json args = { paramFloat };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -197,8 +202,9 @@ void SimpleArrayInterfaceService::onSigFloat(const std::list<float>& paramFloat)
 void SimpleArrayInterfaceService::onSigFloat32(const std::list<float>& paramFloa32)
 {
     const nlohmann::json args = { paramFloa32 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat32");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat32");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -208,8 +214,9 @@ void SimpleArrayInterfaceService::onSigFloat32(const std::list<float>& paramFloa
 void SimpleArrayInterfaceService::onSigFloat64(const std::list<double>& paramFloat64)
 {
     const nlohmann::json args = { paramFloat64 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat64");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat64");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -219,8 +226,9 @@ void SimpleArrayInterfaceService::onSigFloat64(const std::list<double>& paramFlo
 void SimpleArrayInterfaceService::onSigString(const std::list<std::string>& paramString)
 {
     const nlohmann::json args = { paramString };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -229,8 +237,9 @@ void SimpleArrayInterfaceService::onSigString(const std::list<std::string>& para
 }
 void SimpleArrayInterfaceService::onPropBoolChanged(const std::list<bool>& propBool)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propBool);
@@ -239,8 +248,9 @@ void SimpleArrayInterfaceService::onPropBoolChanged(const std::list<bool>& propB
 }
 void SimpleArrayInterfaceService::onPropIntChanged(const std::list<int>& propInt)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propInt);
@@ -249,8 +259,9 @@ void SimpleArrayInterfaceService::onPropIntChanged(const std::list<int>& propInt
 }
 void SimpleArrayInterfaceService::onPropInt32Changed(const std::list<int32_t>& propInt32)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt32");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt32");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propInt32);
@@ -259,8 +270,9 @@ void SimpleArrayInterfaceService::onPropInt32Changed(const std::list<int32_t>& p
 }
 void SimpleArrayInterfaceService::onPropInt64Changed(const std::list<int64_t>& propInt64)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt64");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt64");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propInt64);
@@ -269,8 +281,9 @@ void SimpleArrayInterfaceService::onPropInt64Changed(const std::list<int64_t>& p
 }
 void SimpleArrayInterfaceService::onPropFloatChanged(const std::list<float>& propFloat)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propFloat);
@@ -279,8 +292,9 @@ void SimpleArrayInterfaceService::onPropFloatChanged(const std::list<float>& pro
 }
 void SimpleArrayInterfaceService::onPropFloat32Changed(const std::list<float>& propFloat32)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat32");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat32");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propFloat32);
@@ -289,8 +303,9 @@ void SimpleArrayInterfaceService::onPropFloat32Changed(const std::list<float>& p
 }
 void SimpleArrayInterfaceService::onPropFloat64Changed(const std::list<double>& propFloat64)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat64");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat64");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propFloat64);
@@ -299,8 +314,9 @@ void SimpleArrayInterfaceService::onPropFloat64Changed(const std::list<double>& 
 }
 void SimpleArrayInterfaceService::onPropStringChanged(const std::list<std::string>& propString)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propString);

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_simple/generated/core/tb_simple.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSimple;
@@ -54,7 +53,7 @@ void SimpleInterfaceClient::setPropBool(bool propBool)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
     m_node->setRemoteProperty(propertyId, propBool);
 }
 
@@ -77,7 +76,7 @@ void SimpleInterfaceClient::setPropInt(int propInt)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
     m_node->setRemoteProperty(propertyId, propInt);
 }
 
@@ -100,7 +99,7 @@ void SimpleInterfaceClient::setPropInt32(int32_t propInt32)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt32");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt32");
     m_node->setRemoteProperty(propertyId, propInt32);
 }
 
@@ -123,7 +122,7 @@ void SimpleInterfaceClient::setPropInt64(int64_t propInt64)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt64");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt64");
     m_node->setRemoteProperty(propertyId, propInt64);
 }
 
@@ -146,7 +145,7 @@ void SimpleInterfaceClient::setPropFloat(float propFloat)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
     m_node->setRemoteProperty(propertyId, propFloat);
 }
 
@@ -169,7 +168,7 @@ void SimpleInterfaceClient::setPropFloat32(float propFloat32)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat32");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat32");
     m_node->setRemoteProperty(propertyId, propFloat32);
 }
 
@@ -192,7 +191,7 @@ void SimpleInterfaceClient::setPropFloat64(double propFloat64)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat64");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat64");
     m_node->setRemoteProperty(propertyId, propFloat64);
 }
 
@@ -215,7 +214,7 @@ void SimpleInterfaceClient::setPropString(const std::string& propString)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
     m_node->setRemoteProperty(propertyId, propString);
 }
 
@@ -252,7 +251,7 @@ std::future<bool> SimpleInterfaceClient::funcBoolAsync(bool paramBool)
                     paramBool]()
         {
             std::promise<bool> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramBool}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const bool& value = arg.value.get<bool>();
@@ -283,7 +282,7 @@ std::future<int> SimpleInterfaceClient::funcIntAsync(int paramInt)
                     paramInt]()
         {
             std::promise<int> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramInt}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const int& value = arg.value.get<int>();
@@ -314,7 +313,7 @@ std::future<int32_t> SimpleInterfaceClient::funcInt32Async(int32_t paramInt32)
                     paramInt32]()
         {
             std::promise<int32_t> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt32");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt32");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramInt32}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const int32_t& value = arg.value.get<int32_t>();
@@ -345,7 +344,7 @@ std::future<int64_t> SimpleInterfaceClient::funcInt64Async(int64_t paramInt64)
                     paramInt64]()
         {
             std::promise<int64_t> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt64");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt64");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramInt64}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const int64_t& value = arg.value.get<int64_t>();
@@ -376,7 +375,7 @@ std::future<float> SimpleInterfaceClient::funcFloatAsync(float paramFloat)
                     paramFloat]()
         {
             std::promise<float> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const float& value = arg.value.get<float>();
@@ -407,7 +406,7 @@ std::future<float> SimpleInterfaceClient::funcFloat32Async(float paramFloat32)
                     paramFloat32]()
         {
             std::promise<float> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat32");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat32");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramFloat32}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const float& value = arg.value.get<float>();
@@ -438,7 +437,7 @@ std::future<double> SimpleInterfaceClient::funcFloat64Async(double paramFloat)
                     paramFloat]()
         {
             std::promise<double> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat64");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat64");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const double& value = arg.value.get<double>();
@@ -469,7 +468,7 @@ std::future<std::string> SimpleInterfaceClient::funcStringAsync(const std::strin
                     paramString]()
         {
             std::promise<std::string> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramString}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const std::string& value = arg.value.get<std::string>();

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_simple/generated/api/tb_simple.h"
 #include "tb_simple/generated/core/simpleinterface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceservice.cpp
@@ -142,8 +142,9 @@ nlohmann::json SimpleInterfaceService::olinkCollectProperties()
 void SimpleInterfaceService::onSigBool(bool paramBool)
 {
     const nlohmann::json args = { paramBool };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -153,8 +154,9 @@ void SimpleInterfaceService::onSigBool(bool paramBool)
 void SimpleInterfaceService::onSigInt(int paramInt)
 {
     const nlohmann::json args = { paramInt };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -164,8 +166,9 @@ void SimpleInterfaceService::onSigInt(int paramInt)
 void SimpleInterfaceService::onSigInt32(int32_t paramInt32)
 {
     const nlohmann::json args = { paramInt32 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt32");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt32");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -175,8 +178,9 @@ void SimpleInterfaceService::onSigInt32(int32_t paramInt32)
 void SimpleInterfaceService::onSigInt64(int64_t paramInt64)
 {
     const nlohmann::json args = { paramInt64 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt64");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt64");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -186,8 +190,9 @@ void SimpleInterfaceService::onSigInt64(int64_t paramInt64)
 void SimpleInterfaceService::onSigFloat(float paramFloat)
 {
     const nlohmann::json args = { paramFloat };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -197,8 +202,9 @@ void SimpleInterfaceService::onSigFloat(float paramFloat)
 void SimpleInterfaceService::onSigFloat32(float paramFloa32)
 {
     const nlohmann::json args = { paramFloa32 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat32");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat32");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -208,8 +214,9 @@ void SimpleInterfaceService::onSigFloat32(float paramFloa32)
 void SimpleInterfaceService::onSigFloat64(double paramFloat64)
 {
     const nlohmann::json args = { paramFloat64 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat64");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat64");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -219,8 +226,9 @@ void SimpleInterfaceService::onSigFloat64(double paramFloat64)
 void SimpleInterfaceService::onSigString(const std::string& paramString)
 {
     const nlohmann::json args = { paramString };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -229,8 +237,9 @@ void SimpleInterfaceService::onSigString(const std::string& paramString)
 }
 void SimpleInterfaceService::onPropBoolChanged(bool propBool)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propBool);
@@ -239,8 +248,9 @@ void SimpleInterfaceService::onPropBoolChanged(bool propBool)
 }
 void SimpleInterfaceService::onPropIntChanged(int propInt)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propInt);
@@ -249,8 +259,9 @@ void SimpleInterfaceService::onPropIntChanged(int propInt)
 }
 void SimpleInterfaceService::onPropInt32Changed(int32_t propInt32)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt32");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt32");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propInt32);
@@ -259,8 +270,9 @@ void SimpleInterfaceService::onPropInt32Changed(int32_t propInt32)
 }
 void SimpleInterfaceService::onPropInt64Changed(int64_t propInt64)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt64");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt64");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propInt64);
@@ -269,8 +281,9 @@ void SimpleInterfaceService::onPropInt64Changed(int64_t propInt64)
 }
 void SimpleInterfaceService::onPropFloatChanged(float propFloat)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propFloat);
@@ -279,8 +292,9 @@ void SimpleInterfaceService::onPropFloatChanged(float propFloat)
 }
 void SimpleInterfaceService::onPropFloat32Changed(float propFloat32)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat32");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat32");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propFloat32);
@@ -289,8 +303,9 @@ void SimpleInterfaceService::onPropFloat32Changed(float propFloat32)
 }
 void SimpleInterfaceService::onPropFloat64Changed(double propFloat64)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat64");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat64");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propFloat64);
@@ -299,8 +314,9 @@ void SimpleInterfaceService::onPropFloat64Changed(double propFloat64)
 }
 void SimpleInterfaceService::onPropStringChanged(const std::string& propString)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propString);

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/voidinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/voidinterfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "tb_simple/generated/core/tb_simple.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSimple;
@@ -37,7 +36,7 @@ void VoidInterfaceClient::funcVoid()
             (void) arg;
         };
     const nlohmann::json &args = nlohmann::json::array({  });
-    const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
     m_node->invokeRemote(operationId, args, func);
 }
 
@@ -50,7 +49,7 @@ std::future<void> VoidInterfaceClient::funcVoidAsync()
     return std::async(std::launch::async, [this]()
         {
             std::promise<void> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     (void) arg;

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/voidinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/voidinterfaceclient.h
@@ -5,7 +5,6 @@
 #include "tb_simple/generated/api/tb_simple.h"
 #include "tb_simple/generated/core/voidinterface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/voidinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/voidinterfaceservice.cpp
@@ -70,8 +70,9 @@ nlohmann::json VoidInterfaceService::olinkCollectProperties()
 void VoidInterfaceService::onSigVoid()
 {
     const nlohmann::json args = {  };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigVoid");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigVoid");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceclient.cpp
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "testbed1/generated/core/testbed1.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::Testbed1;
@@ -42,7 +41,7 @@ void StructArrayInterfaceClient::setPropBool(const std::list<StructBool>& propBo
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
     m_node->setRemoteProperty(propertyId, propBool);
 }
 
@@ -65,7 +64,7 @@ void StructArrayInterfaceClient::setPropInt(const std::list<StructInt>& propInt)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
     m_node->setRemoteProperty(propertyId, propInt);
 }
 
@@ -88,7 +87,7 @@ void StructArrayInterfaceClient::setPropFloat(const std::list<StructFloat>& prop
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
     m_node->setRemoteProperty(propertyId, propFloat);
 }
 
@@ -111,7 +110,7 @@ void StructArrayInterfaceClient::setPropString(const std::list<StructString>& pr
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
     m_node->setRemoteProperty(propertyId, propString);
 }
 
@@ -148,7 +147,7 @@ std::future<StructBool> StructArrayInterfaceClient::funcBoolAsync(const std::lis
                     paramBool]()
         {
             std::promise<StructBool> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramBool}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const StructBool& value = arg.value.get<StructBool>();
@@ -179,7 +178,7 @@ std::future<StructBool> StructArrayInterfaceClient::funcIntAsync(const std::list
                     paramInt]()
         {
             std::promise<StructBool> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramInt}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const StructBool& value = arg.value.get<StructBool>();
@@ -210,7 +209,7 @@ std::future<StructBool> StructArrayInterfaceClient::funcFloatAsync(const std::li
                     paramFloat]()
         {
             std::promise<StructBool> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const StructBool& value = arg.value.get<StructBool>();
@@ -241,7 +240,7 @@ std::future<StructBool> StructArrayInterfaceClient::funcStringAsync(const std::l
                     paramString]()
         {
             std::promise<StructBool> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramString}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const StructBool& value = arg.value.get<StructBool>();

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceclient.h
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceclient.h
@@ -5,7 +5,6 @@
 #include "testbed1/generated/api/testbed1.h"
 #include "testbed1/generated/core/structarrayinterface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceservice.cpp
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceservice.cpp
@@ -102,8 +102,9 @@ nlohmann::json StructArrayInterfaceService::olinkCollectProperties()
 void StructArrayInterfaceService::onSigBool(const std::list<StructBool>& paramBool)
 {
     const nlohmann::json args = { paramBool };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -113,8 +114,9 @@ void StructArrayInterfaceService::onSigBool(const std::list<StructBool>& paramBo
 void StructArrayInterfaceService::onSigInt(const std::list<StructInt>& paramInt)
 {
     const nlohmann::json args = { paramInt };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -124,8 +126,9 @@ void StructArrayInterfaceService::onSigInt(const std::list<StructInt>& paramInt)
 void StructArrayInterfaceService::onSigFloat(const std::list<StructFloat>& paramFloat)
 {
     const nlohmann::json args = { paramFloat };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -135,8 +138,9 @@ void StructArrayInterfaceService::onSigFloat(const std::list<StructFloat>& param
 void StructArrayInterfaceService::onSigString(const std::list<StructString>& paramString)
 {
     const nlohmann::json args = { paramString };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -145,8 +149,9 @@ void StructArrayInterfaceService::onSigString(const std::list<StructString>& par
 }
 void StructArrayInterfaceService::onPropBoolChanged(const std::list<StructBool>& propBool)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propBool);
@@ -155,8 +160,9 @@ void StructArrayInterfaceService::onPropBoolChanged(const std::list<StructBool>&
 }
 void StructArrayInterfaceService::onPropIntChanged(const std::list<StructInt>& propInt)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propInt);
@@ -165,8 +171,9 @@ void StructArrayInterfaceService::onPropIntChanged(const std::list<StructInt>& p
 }
 void StructArrayInterfaceService::onPropFloatChanged(const std::list<StructFloat>& propFloat)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propFloat);
@@ -175,8 +182,9 @@ void StructArrayInterfaceService::onPropFloatChanged(const std::list<StructFloat
 }
 void StructArrayInterfaceService::onPropStringChanged(const std::list<StructString>& propString)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propString);

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structinterfaceclient.cpp
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structinterfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "testbed1/generated/core/testbed1.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::Testbed1;
@@ -42,7 +41,7 @@ void StructInterfaceClient::setPropBool(const StructBool& propBool)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
     m_node->setRemoteProperty(propertyId, propBool);
 }
 
@@ -65,7 +64,7 @@ void StructInterfaceClient::setPropInt(const StructInt& propInt)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
     m_node->setRemoteProperty(propertyId, propInt);
 }
 
@@ -88,7 +87,7 @@ void StructInterfaceClient::setPropFloat(const StructFloat& propFloat)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
     m_node->setRemoteProperty(propertyId, propFloat);
 }
 
@@ -111,7 +110,7 @@ void StructInterfaceClient::setPropString(const StructString& propString)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
     m_node->setRemoteProperty(propertyId, propString);
 }
 
@@ -148,7 +147,7 @@ std::future<StructBool> StructInterfaceClient::funcBoolAsync(const StructBool& p
                     paramBool]()
         {
             std::promise<StructBool> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramBool}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const StructBool& value = arg.value.get<StructBool>();
@@ -179,7 +178,7 @@ std::future<StructBool> StructInterfaceClient::funcIntAsync(const StructInt& par
                     paramInt]()
         {
             std::promise<StructBool> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramInt}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const StructBool& value = arg.value.get<StructBool>();
@@ -210,7 +209,7 @@ std::future<StructFloat> StructInterfaceClient::funcFloatAsync(const StructFloat
                     paramFloat]()
         {
             std::promise<StructFloat> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const StructFloat& value = arg.value.get<StructFloat>();
@@ -241,7 +240,7 @@ std::future<StructString> StructInterfaceClient::funcStringAsync(const StructStr
                     paramString]()
         {
             std::promise<StructString> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({paramString}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const StructString& value = arg.value.get<StructString>();

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structinterfaceclient.h
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structinterfaceclient.h
@@ -5,7 +5,6 @@
 #include "testbed1/generated/api/testbed1.h"
 #include "testbed1/generated/core/structinterface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structinterfaceservice.cpp
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structinterfaceservice.cpp
@@ -102,8 +102,9 @@ nlohmann::json StructInterfaceService::olinkCollectProperties()
 void StructInterfaceService::onSigBool(const StructBool& paramBool)
 {
     const nlohmann::json args = { paramBool };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -113,8 +114,9 @@ void StructInterfaceService::onSigBool(const StructBool& paramBool)
 void StructInterfaceService::onSigInt(const StructInt& paramInt)
 {
     const nlohmann::json args = { paramInt };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -124,8 +126,9 @@ void StructInterfaceService::onSigInt(const StructInt& paramInt)
 void StructInterfaceService::onSigFloat(const StructFloat& paramFloat)
 {
     const nlohmann::json args = { paramFloat };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -135,8 +138,9 @@ void StructInterfaceService::onSigFloat(const StructFloat& paramFloat)
 void StructInterfaceService::onSigString(const StructString& paramString)
 {
     const nlohmann::json args = { paramString };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -145,8 +149,9 @@ void StructInterfaceService::onSigString(const StructString& paramString)
 }
 void StructInterfaceService::onPropBoolChanged(const StructBool& propBool)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propBool);
@@ -155,8 +160,9 @@ void StructInterfaceService::onPropBoolChanged(const StructBool& propBool)
 }
 void StructInterfaceService::onPropIntChanged(const StructInt& propInt)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propInt);
@@ -165,8 +171,9 @@ void StructInterfaceService::onPropIntChanged(const StructInt& propInt)
 }
 void StructInterfaceService::onPropFloatChanged(const StructFloat& propFloat)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propFloat);
@@ -175,8 +182,9 @@ void StructInterfaceService::onPropFloatChanged(const StructFloat& propFloat)
 }
 void StructInterfaceService::onPropStringChanged(const StructString& propString)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propString);

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceclient.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "testbed2/generated/core/testbed2.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::Testbed2;
@@ -42,7 +41,7 @@ void ManyParamInterfaceClient::setProp1(int prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -65,7 +64,7 @@ void ManyParamInterfaceClient::setProp2(int prop2)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
     m_node->setRemoteProperty(propertyId, prop2);
 }
 
@@ -88,7 +87,7 @@ void ManyParamInterfaceClient::setProp3(int prop3)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
     m_node->setRemoteProperty(propertyId, prop3);
 }
 
@@ -111,7 +110,7 @@ void ManyParamInterfaceClient::setProp4(int prop4)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop4");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop4");
     m_node->setRemoteProperty(propertyId, prop4);
 }
 
@@ -148,7 +147,7 @@ std::future<int> ManyParamInterfaceClient::func1Async(int param1)
                     param1]()
         {
             std::promise<int> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const int& value = arg.value.get<int>();
@@ -180,7 +179,7 @@ std::future<int> ManyParamInterfaceClient::func2Async(int param1, int param2)
                     param2]()
         {
             std::promise<int> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const int& value = arg.value.get<int>();
@@ -213,7 +212,7 @@ std::future<int> ManyParamInterfaceClient::func3Async(int param1, int param2, in
                     param3]()
         {
             std::promise<int> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func3");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func3");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1, param2, param3}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const int& value = arg.value.get<int>();
@@ -247,7 +246,7 @@ std::future<int> ManyParamInterfaceClient::func4Async(int param1, int param2, in
                     param4]()
         {
             std::promise<int> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func4");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func4");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1, param2, param3, param4}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const int& value = arg.value.get<int>();

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceclient.h
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceclient.h
@@ -5,7 +5,6 @@
 #include "testbed2/generated/api/testbed2.h"
 #include "testbed2/generated/core/manyparaminterface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceservice.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceservice.cpp
@@ -108,8 +108,9 @@ nlohmann::json ManyParamInterfaceService::olinkCollectProperties()
 void ManyParamInterfaceService::onSig1(int param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -119,8 +120,9 @@ void ManyParamInterfaceService::onSig1(int param1)
 void ManyParamInterfaceService::onSig2(int param1, int param2)
 {
     const nlohmann::json args = { param1, param2 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -130,8 +132,9 @@ void ManyParamInterfaceService::onSig2(int param1, int param2)
 void ManyParamInterfaceService::onSig3(int param1, int param2, int param3)
 {
     const nlohmann::json args = { param1, param2, param3 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig3");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig3");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -141,8 +144,9 @@ void ManyParamInterfaceService::onSig3(int param1, int param2, int param3)
 void ManyParamInterfaceService::onSig4(int param1, int param2, int param3, int param4)
 {
     const nlohmann::json args = { param1, param2, param3, param4 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig4");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig4");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -151,8 +155,9 @@ void ManyParamInterfaceService::onSig4(int param1, int param2, int param3, int p
 }
 void ManyParamInterfaceService::onProp1Changed(int prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);
@@ -161,8 +166,9 @@ void ManyParamInterfaceService::onProp1Changed(int prop1)
 }
 void ManyParamInterfaceService::onProp2Changed(int prop2)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop2);
@@ -171,8 +177,9 @@ void ManyParamInterfaceService::onProp2Changed(int prop2)
 }
 void ManyParamInterfaceService::onProp3Changed(int prop3)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop3);
@@ -181,8 +188,9 @@ void ManyParamInterfaceService::onProp3Changed(int prop3)
 }
 void ManyParamInterfaceService::onProp4Changed(int prop4)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop4");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop4");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop4);

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct1interfaceclient.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct1interfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "testbed2/generated/core/testbed2.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::Testbed2;
@@ -33,7 +32,7 @@ void NestedStruct1InterfaceClient::setProp1(const NestedStruct1& prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -70,7 +69,7 @@ std::future<NestedStruct1> NestedStruct1InterfaceClient::func1Async(const Nested
                     param1]()
         {
             std::promise<NestedStruct1> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const NestedStruct1& value = arg.value.get<NestedStruct1>();

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct1interfaceclient.h
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct1interfaceclient.h
@@ -5,7 +5,6 @@
 #include "testbed2/generated/api/testbed2.h"
 #include "testbed2/generated/core/nestedstruct1interface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct1interfaceservice.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct1interfaceservice.cpp
@@ -72,8 +72,9 @@ nlohmann::json NestedStruct1InterfaceService::olinkCollectProperties()
 void NestedStruct1InterfaceService::onSig1(const NestedStruct1& param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -82,8 +83,9 @@ void NestedStruct1InterfaceService::onSig1(const NestedStruct1& param1)
 }
 void NestedStruct1InterfaceService::onProp1Changed(const NestedStruct1& prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceclient.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "testbed2/generated/core/testbed2.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::Testbed2;
@@ -36,7 +35,7 @@ void NestedStruct2InterfaceClient::setProp1(const NestedStruct1& prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -59,7 +58,7 @@ void NestedStruct2InterfaceClient::setProp2(const NestedStruct2& prop2)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
     m_node->setRemoteProperty(propertyId, prop2);
 }
 
@@ -96,7 +95,7 @@ std::future<NestedStruct1> NestedStruct2InterfaceClient::func1Async(const Nested
                     param1]()
         {
             std::promise<NestedStruct1> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const NestedStruct1& value = arg.value.get<NestedStruct1>();
@@ -128,7 +127,7 @@ std::future<NestedStruct1> NestedStruct2InterfaceClient::func2Async(const Nested
                     param2]()
         {
             std::promise<NestedStruct1> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const NestedStruct1& value = arg.value.get<NestedStruct1>();

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceclient.h
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceclient.h
@@ -5,7 +5,6 @@
 #include "testbed2/generated/api/testbed2.h"
 #include "testbed2/generated/core/nestedstruct2interface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceservice.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceservice.cpp
@@ -83,8 +83,9 @@ nlohmann::json NestedStruct2InterfaceService::olinkCollectProperties()
 void NestedStruct2InterfaceService::onSig1(const NestedStruct1& param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -94,8 +95,9 @@ void NestedStruct2InterfaceService::onSig1(const NestedStruct1& param1)
 void NestedStruct2InterfaceService::onSig2(const NestedStruct1& param1, const NestedStruct2& param2)
 {
     const nlohmann::json args = { param1, param2 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -104,8 +106,9 @@ void NestedStruct2InterfaceService::onSig2(const NestedStruct1& param1, const Ne
 }
 void NestedStruct2InterfaceService::onProp1Changed(const NestedStruct1& prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);
@@ -114,8 +117,9 @@ void NestedStruct2InterfaceService::onProp1Changed(const NestedStruct1& prop1)
 }
 void NestedStruct2InterfaceService::onProp2Changed(const NestedStruct2& prop2)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop2);

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceclient.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceclient.cpp
@@ -5,7 +5,6 @@
 #include "testbed2/generated/core/testbed2.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::Testbed2;
@@ -39,7 +38,7 @@ void NestedStruct3InterfaceClient::setProp1(const NestedStruct1& prop1)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
     m_node->setRemoteProperty(propertyId, prop1);
 }
 
@@ -62,7 +61,7 @@ void NestedStruct3InterfaceClient::setProp2(const NestedStruct2& prop2)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
     m_node->setRemoteProperty(propertyId, prop2);
 }
 
@@ -85,7 +84,7 @@ void NestedStruct3InterfaceClient::setProp3(const NestedStruct3& prop3)
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
     m_node->setRemoteProperty(propertyId, prop3);
 }
 
@@ -122,7 +121,7 @@ std::future<NestedStruct1> NestedStruct3InterfaceClient::func1Async(const Nested
                     param1]()
         {
             std::promise<NestedStruct1> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const NestedStruct1& value = arg.value.get<NestedStruct1>();
@@ -154,7 +153,7 @@ std::future<NestedStruct1> NestedStruct3InterfaceClient::func2Async(const Nested
                     param2]()
         {
             std::promise<NestedStruct1> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const NestedStruct1& value = arg.value.get<NestedStruct1>();
@@ -187,7 +186,7 @@ std::future<NestedStruct1> NestedStruct3InterfaceClient::func3Async(const Nested
                     param3]()
         {
             std::promise<NestedStruct1> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func3");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func3");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({param1, param2, param3}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     const NestedStruct1& value = arg.value.get<NestedStruct1>();

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceclient.h
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceclient.h
@@ -5,7 +5,6 @@
 #include "testbed2/generated/api/testbed2.h"
 #include "testbed2/generated/core/nestedstruct3interface.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceservice.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceservice.cpp
@@ -95,8 +95,9 @@ nlohmann::json NestedStruct3InterfaceService::olinkCollectProperties()
 void NestedStruct3InterfaceService::onSig1(const NestedStruct1& param1)
 {
     const nlohmann::json args = { param1 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -106,8 +107,9 @@ void NestedStruct3InterfaceService::onSig1(const NestedStruct1& param1)
 void NestedStruct3InterfaceService::onSig2(const NestedStruct1& param1, const NestedStruct2& param2)
 {
     const nlohmann::json args = { param1, param2 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -117,8 +119,9 @@ void NestedStruct3InterfaceService::onSig2(const NestedStruct1& param1, const Ne
 void NestedStruct3InterfaceService::onSig3(const NestedStruct1& param1, const NestedStruct2& param2, const NestedStruct3& param3)
 {
     const nlohmann::json args = { param1, param2, param3 };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig3");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig3");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -127,8 +130,9 @@ void NestedStruct3InterfaceService::onSig3(const NestedStruct1& param1, const Ne
 }
 void NestedStruct3InterfaceService::onProp1Changed(const NestedStruct1& prop1)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop1);
@@ -137,8 +141,9 @@ void NestedStruct3InterfaceService::onProp1Changed(const NestedStruct1& prop1)
 }
 void NestedStruct3InterfaceService::onProp2Changed(const NestedStruct2& prop2)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop2);
@@ -147,8 +152,9 @@ void NestedStruct3InterfaceService::onProp2Changed(const NestedStruct2& prop2)
 }
 void NestedStruct3InterfaceService::onProp3Changed(const NestedStruct3& prop3)
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, prop3);

--- a/templates/module/generated/olink/interfaceclient.cpp.tpl
+++ b/templates/module/generated/olink/interfaceclient.cpp.tpl
@@ -13,7 +13,6 @@
 #include "{{snake .Module.Name}}/generated/core/{{snake .Module.Name}}.json.adapter.h"
 
 #include "olink/iclientnode.h"
-#include "apigear/olink/olinkconnection.h"
 #include "apigear/utilities/logger.h"
 
 using namespace {{ Camel .System.Name }}::{{ Camel .Module.Name }};
@@ -51,7 +50,7 @@ void {{$class}}::set{{Camel $name}}({{cppParam "" $property}})
         AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
         return;
     }
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "{{$property.Name}}");
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "{{$property.Name}}");
     m_node->setRemoteProperty(propertyId, {{$property.Name}});
 }
 
@@ -92,7 +91,7 @@ void {{$class}}::set{{Camel $name}}Local({{cppParam "" $property }})
             (void) arg;
         };
     const nlohmann::json &args = nlohmann::json::array({ {{ cppVars $operation.Params}} });
-    const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "{{$operation.Name}}");
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "{{$operation.Name}}");
     m_node->invokeRemote(operationId, args, func);
     {{- else }}
     {{$returnType}} value({{lower1 $operation.Name}}Async({{ cppVars $operation.Params }}).get());
@@ -111,7 +110,7 @@ std::future<{{$returnType}}> {{$class}}::{{$operation.Name| lower1}}Async({{cppP
                 {{- end -}}]()
         {
             std::promise<{{$returnType}}> resultPromise;
-            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "{{$operation.Name}}");
+            static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "{{$operation.Name}}");
             m_node->invokeRemote(operationId,
                 nlohmann::json::array({ {{- cppVars $operation.Params -}} }), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {        
                     {{- if ( eq (cppReturn "" $operation.Return) "void") }}

--- a/templates/module/generated/olink/interfaceclient.h.tpl
+++ b/templates/module/generated/olink/interfaceclient.h.tpl
@@ -11,7 +11,6 @@
 #include "{{snake .Module.Name}}/generated/api/{{snake .Module.Name}}.h"
 #include "{{snake .Module.Name}}/generated/core/{{lower $interfaceName}}.data.h"
 
-#include "apigear/olink/iolinkconnector.h"
 #include "olink/iobjectsink.h"
 
 #include <future>

--- a/templates/module/generated/olink/interfaceservice.cpp.tpl
+++ b/templates/module/generated/olink/interfaceservice.cpp.tpl
@@ -113,8 +113,9 @@ nlohmann::json {{$class}}::olinkCollectProperties()
 void {{$class}}::on{{Camel $signal.Name}}({{cppParams "" $signal.Params}})
 {
     const nlohmann::json args = { {{ cppVars $signal.Params}} };
-    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "{{$signal.Name}}");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "{{$signal.Name}}");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifySignal(signalId, args);
@@ -127,8 +128,9 @@ void {{$class}}::on{{Camel $signal.Name}}({{cppParams "" $signal.Params}})
 {{- $property := . }}
 void {{$class}}::on{{Camel $property.Name}}Changed({{cppParam "" $property}})
 {
-    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "{{$property.Name}}");
-    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "{{$property.Name}}");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, {{$property}});


### PR DESCRIPTION
minimize calling olinkObjectName() and createMemberId() by adding static const variables in functions.
This was called a lot, and new string had to be allocated each time for the memberId, which doesn't change during the program lifetime. Now it is created only once