### PR TITLE
Fix conan build on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tsconfig.tsbuildinfo
 demo/
 
 goldenmaster/build/*
+goldenmaster/**/CMakeUserPresets.json
 .vs/*
 
 # folder for apigear binary

--- a/goldenmaster/apigear/conanfile.py
+++ b/goldenmaster/apigear/conanfile.py
@@ -34,7 +34,7 @@ class apigearConan(ConanFile):
                        "poco:enable_redis": False,
                        "poco:enable_sevenzip": False,
                        "poco:enable_util": True,
-                       "poco:enable_xml": True,
+                       "poco:enable_xml": False,
                        "poco:enable_zip": False
                        }
     exports_sources = "*"

--- a/goldenmaster/examples/app/CMakeLists.txt
+++ b/goldenmaster/examples/app/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(App)
 cmake_minimum_required(VERSION 3.1)
+project(App)
 
 # append local binary directory for conan packages to be found
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})

--- a/goldenmaster/examples/app/conanfile.txt
+++ b/goldenmaster/examples/app/conanfile.txt
@@ -8,4 +8,5 @@ testbed1/1.0
 
 [generators]
 cmake_find_package
+CMakeToolchain
 virtualenv

--- a/goldenmaster/examples/appthreadsafe/CMakeLists.txt
+++ b/goldenmaster/examples/appthreadsafe/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(AppThreadSafe)
 cmake_minimum_required(VERSION 3.1)
+project(AppThreadSafe)
 
 # append local binary directory for conan packages to be found
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})

--- a/goldenmaster/examples/appthreadsafe/conanfile.txt
+++ b/goldenmaster/examples/appthreadsafe/conanfile.txt
@@ -8,4 +8,5 @@ testbed1/1.0
 
 [generators]
 cmake_find_package
+CMakeToolchain
 virtualenv

--- a/goldenmaster/examples/olinkclient/CMakeLists.txt
+++ b/goldenmaster/examples/olinkclient/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(OLinkClient)
 cmake_minimum_required(VERSION 3.1)
+project(OLinkClient)
 
 # append local binary directory for conan packages to be found
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})

--- a/goldenmaster/examples/olinkclient/conanfile.txt
+++ b/goldenmaster/examples/olinkclient/conanfile.txt
@@ -8,4 +8,5 @@ testbed1/1.0
 
 [generators]
 cmake_find_package
+CMakeToolchain
 virtualenv

--- a/goldenmaster/examples/olinkserver/CMakeLists.txt
+++ b/goldenmaster/examples/olinkserver/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(OLinkServer)
 cmake_minimum_required(VERSION 3.1)
+project(OLinkServer)
 
 # append local binary directory for conan packages to be found
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})

--- a/goldenmaster/examples/olinkserver/conanfile.txt
+++ b/goldenmaster/examples/olinkserver/conanfile.txt
@@ -8,4 +8,5 @@ testbed1/1.0
 
 [generators]
 cmake_find_package
+CMakeToolchain
 virtualenv

--- a/goldenmaster/test_conan.bat
+++ b/goldenmaster/test_conan.bat
@@ -118,67 +118,68 @@ if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 conan create ../../../modules/testbed1_module
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 popd
+@REM Leave build folder
+cd ..
 @REM Building examples app
-if not exist examples\app mkdir examples\app
+if not exist build\examples\app mkdir build\examples\app
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 pushd examples\app
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-conan install --build missing ../../../examples/app -g=virtualenv
+conan install --build missing . --install-folder ../../build/examples/app -g=virtualenv
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake ../../../examples/app
+cmake -S . -B ../../build/examples/app --preset default
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL activate.bat
+CALL ../../build/examples/app/activate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake --build .
+cmake --build ../../build/examples/app
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL deactivate.bat
+CALL ../../build/examples/app/deactivate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 popd
 @REM Building examples appthreadsafe
-if not exist examples\appthreadsafe mkdir examples\appthreadsafe
+if not exist build\examples\appthreadsafe mkdir build\examples\appthreadsafe
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 pushd examples\appthreadsafe
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-conan install --build missing ../../../examples/appthreadsafe -g=virtualenv
+conan install --build missing . --install-folder ../../build/examples/appthreadsafe -g=virtualenv
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake ../../../examples/appthreadsafe
+cmake -S . -B ../../build/examples/appthreadsafe --preset default
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL activate.bat
+CALL ../../build/examples/appthreadsafe/activate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake --build .
+cmake --build ../../build/examples/appthreadsafe
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL deactivate.bat
+CALL ../../build/examples/appthreadsafe/deactivate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 popd
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-if not exist examples\olinkserver mkdir examples\olinkserver
+if not exist build\examples\olinkserver mkdir build\examples\olinkserver
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 pushd examples\olinkserver
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-conan install --build missing ../../../examples/olinkserver -g=virtualenv
+conan install --build missing . --install-folder ../../build/examples/olinkserver -g=virtualenv
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake ../../../examples/olinkserver
+cmake -S . -B ../../build/examples/olinkserver --preset default
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL activate.bat
+CALL ../../build/examples/olinkserver/activate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake --build .
+cmake --build ../../build/examples/olinkserver
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL deactivate.bat
+CALL ../../build/examples/olinkserver/deactivate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 popd
-if not exist examples\olinkclient mkdir examples\olinkclient
+if not exist build\examples\olinkclient mkdir build\examples\olinkclient
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 pushd examples\olinkclient
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-conan install --build missing ../../../examples/olinkclient -g=virtualenv
+conan install --build missing . --install-folder ../../build/examples/olinkclient -g=virtualenv
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake ../../../examples/olinkclient
+cmake -S . -B ../../build/examples/olinkclient --preset default
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL activate.bat
+CALL ../../build/examples/olinkclient/activate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake --build .
+cmake --build ../../build/examples/olinkclient
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL deactivate.bat
+CALL ../../build/examples/olinkclient/deactivate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 popd
-cd ..

--- a/goldenmaster/test_conan.sh
+++ b/goldenmaster/test_conan.sh
@@ -100,25 +100,27 @@ conan install --build missing ../../../modules/testbed1_module &&\
 conan create ../../../modules/testbed1_module
 if [ $? -ne 0 ]; then exit 1; fi;
 popd
+# leave build directory
+cd ..
 # examples app
-mkdir -p examples/app;
+mkdir -p build/examples/app;
 pushd examples/app;
-conan install --build missing ../../../examples/app -g=virtualenv && cmake ../../../examples/app && cmake --build .
+conan install --build missing . --install-folder ../../build/examples/app -g=virtualenv && cmake -S . -B ../../build/examples/app --preset release && cmake --build ../../build/examples/app
 if [ $? -ne 0 ]; then exit 1; fi;
 popd
 # examples appthreadsafe
-mkdir -p examples/appthreadsafe;
+mkdir -p build/examples/appthreadsafe;
 pushd examples/appthreadsafe;
-conan install --build missing ../../../examples/appthreadsafe -g=virtualenv && cmake ../../../examples/appthreadsafe && cmake --build .
+conan install --build missing . --install-folder ../../build/examples/appthreadsafe -g=virtualenv && cmake  -S . -B ../../build/examples/appthreadsafe --preset release && cmake --build ../../build/examples/appthreadsafe
 if [ $? -ne 0 ]; then exit 1; fi;
 popd
-mkdir -p examples/olinkserver;
+mkdir -p build/examples/olinkserver;
 pushd examples/olinkserver;
-conan install --build missing ../../../examples/olinkserver -g=virtualenv && cmake ../../../examples/olinkserver && cmake --build .
+conan install --build missing . --install-folder ../../build/examples/olinkserver -g=virtualenv && cmake -S . -B ../../build/examples/olinkserver --preset release && cmake --build ../../build/examples/olinkserver
 if [ $? -ne 0 ]; then exit 1; fi;
 popd
-mkdir -p examples/olinkclient;
+mkdir -p build/examples/olinkclient;
 pushd examples/olinkclient;
-conan install --build missing ../../../examples/olinkclient -g=virtualenv && cmake ../../../examples/olinkclient && cmake --build .
+conan install --build missing . --install-folder ../../build/examples/olinkclient -g=virtualenv && cmake -S . -B ../../build/examples/olinkclient --preset release && cmake --build ../../build/examples/olinkclient
 if [ $? -ne 0 ]; then exit 1; fi;
 popd

--- a/templates/apigear/conanfile.py
+++ b/templates/apigear/conanfile.py
@@ -34,7 +34,7 @@ class apigearConan(ConanFile):
                        "poco:enable_redis": False,
                        "poco:enable_sevenzip": False,
                        "poco:enable_util": True,
-                       "poco:enable_xml": True,
+                       "poco:enable_xml": False,
                        "poco:enable_zip": False
                        }
     exports_sources = "*"

--- a/templates/examples/app/CMakeLists.txt.tpl
+++ b/templates/examples/app/CMakeLists.txt.tpl
@@ -1,5 +1,5 @@
-project(App)
 cmake_minimum_required(VERSION 3.1)
+project(App)
 
 # append local binary directory for conan packages to be found
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})

--- a/templates/examples/app/conanfile.txt.tpl
+++ b/templates/examples/app/conanfile.txt.tpl
@@ -6,4 +6,5 @@
 
 [generators]
 cmake_find_package
+CMakeToolchain
 virtualenv

--- a/templates/examples/appthreadsafe/CMakeLists.txt.tpl
+++ b/templates/examples/appthreadsafe/CMakeLists.txt.tpl
@@ -1,5 +1,5 @@
-project(AppThreadSafe)
 cmake_minimum_required(VERSION 3.1)
+project(AppThreadSafe)
 
 # append local binary directory for conan packages to be found
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})

--- a/templates/examples/appthreadsafe/conanfile.txt.tpl
+++ b/templates/examples/appthreadsafe/conanfile.txt.tpl
@@ -6,4 +6,5 @@
 
 [generators]
 cmake_find_package
+CMakeToolchain
 virtualenv

--- a/templates/examples/olinkclient/CMakeLists.txt.tpl
+++ b/templates/examples/olinkclient/CMakeLists.txt.tpl
@@ -1,5 +1,5 @@
-project(OLinkClient)
 cmake_minimum_required(VERSION 3.1)
+project(OLinkClient)
 
 # append local binary directory for conan packages to be found
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})

--- a/templates/examples/olinkclient/conanfile.txt.tpl
+++ b/templates/examples/olinkclient/conanfile.txt.tpl
@@ -6,4 +6,5 @@
 
 [generators]
 cmake_find_package
+CMakeToolchain
 virtualenv

--- a/templates/examples/olinkserver/CMakeLists.txt.tpl
+++ b/templates/examples/olinkserver/CMakeLists.txt.tpl
@@ -1,5 +1,5 @@
-project(OLinkServer)
 cmake_minimum_required(VERSION 3.1)
+project(OLinkServer)
 
 # append local binary directory for conan packages to be found
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})

--- a/templates/examples/olinkserver/conanfile.txt.tpl
+++ b/templates/examples/olinkserver/conanfile.txt.tpl
@@ -6,4 +6,5 @@
 
 [generators]
 cmake_find_package
+CMakeToolchain
 virtualenv

--- a/templates/test_conan.bat.tpl
+++ b/templates/test_conan.bat.tpl
@@ -43,71 +43,72 @@ conan create ../../../modules/{{snake .Name}}_module
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 popd
 {{- end }}
+@REM Leave build folder
+cd ..
 {{- if $features.examples }}
 @REM Building examples app
-if not exist examples\app mkdir examples\app
+if not exist build\examples\app mkdir build\examples\app
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 pushd examples\app
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-conan install --build missing ../../../examples/app -g=virtualenv
+conan install --build missing . --install-folder ../../build/examples/app -g=virtualenv
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake ../../../examples/app
+cmake -S . -B ../../build/examples/app --preset default
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL activate.bat
+CALL ../../build/examples/app/activate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake --build .
+cmake --build ../../build/examples/app
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL deactivate.bat
+CALL ../../build/examples/app/deactivate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 popd
 @REM Building examples appthreadsafe
-if not exist examples\appthreadsafe mkdir examples\appthreadsafe
+if not exist build\examples\appthreadsafe mkdir build\examples\appthreadsafe
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 pushd examples\appthreadsafe
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-conan install --build missing ../../../examples/appthreadsafe -g=virtualenv
+conan install --build missing . --install-folder ../../build/examples/appthreadsafe -g=virtualenv
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake ../../../examples/appthreadsafe
+cmake -S . -B ../../build/examples/appthreadsafe --preset default
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL activate.bat
+CALL ../../build/examples/appthreadsafe/activate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake --build .
+cmake --build ../../build/examples/appthreadsafe
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL deactivate.bat
+CALL ../../build/examples/appthreadsafe/deactivate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 popd
 {{- end}}
 {{- if $features.examples_olink }}
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-if not exist examples\olinkserver mkdir examples\olinkserver
+if not exist build\examples\olinkserver mkdir build\examples\olinkserver
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 pushd examples\olinkserver
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-conan install --build missing ../../../examples/olinkserver -g=virtualenv
+conan install --build missing . --install-folder ../../build/examples/olinkserver -g=virtualenv
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake ../../../examples/olinkserver
+cmake -S . -B ../../build/examples/olinkserver --preset default
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL activate.bat
+CALL ../../build/examples/olinkserver/activate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake --build .
+cmake --build ../../build/examples/olinkserver
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL deactivate.bat
+CALL ../../build/examples/olinkserver/deactivate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 popd
-if not exist examples\olinkclient mkdir examples\olinkclient
+if not exist build\examples\olinkclient mkdir build\examples\olinkclient
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 pushd examples\olinkclient
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-conan install --build missing ../../../examples/olinkclient -g=virtualenv
+conan install --build missing . --install-folder ../../build/examples/olinkclient -g=virtualenv
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake ../../../examples/olinkclient
+cmake -S . -B ../../build/examples/olinkclient --preset default
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL activate.bat
+CALL ../../build/examples/olinkclient/activate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-cmake --build .
+cmake --build ../../build/examples/olinkclient
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-CALL deactivate.bat
+CALL ../../build/examples/olinkclient/deactivate.bat
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 popd
 {{- end}}
-cd ..

--- a/templates/test_conan.sh.tpl
+++ b/templates/test_conan.sh.tpl
@@ -30,29 +30,31 @@ conan create ../../../modules/{{ snake .Name }}_module
 if [ $? -ne 0 ]; then exit 1; fi;
 popd
 {{- end }}
+# leave build directory
+cd ..
 {{- if $features.examples }}
 # examples app
-mkdir -p examples/app;
+mkdir -p build/examples/app;
 pushd examples/app;
-conan install --build missing ../../../examples/app -g=virtualenv && cmake ../../../examples/app && cmake --build .
+conan install --build missing . --install-folder ../../build/examples/app -g=virtualenv && cmake -S . -B ../../build/examples/app --preset release && cmake --build ../../build/examples/app
 if [ $? -ne 0 ]; then exit 1; fi;
 popd
 # examples appthreadsafe
-mkdir -p examples/appthreadsafe;
+mkdir -p build/examples/appthreadsafe;
 pushd examples/appthreadsafe;
-conan install --build missing ../../../examples/appthreadsafe -g=virtualenv && cmake ../../../examples/appthreadsafe && cmake --build .
+conan install --build missing . --install-folder ../../build/examples/appthreadsafe -g=virtualenv && cmake  -S . -B ../../build/examples/appthreadsafe --preset release && cmake --build ../../build/examples/appthreadsafe
 if [ $? -ne 0 ]; then exit 1; fi;
 popd
 {{- end}}
 {{- if $features.examples_olink }}
-mkdir -p examples/olinkserver;
+mkdir -p build/examples/olinkserver;
 pushd examples/olinkserver;
-conan install --build missing ../../../examples/olinkserver -g=virtualenv && cmake ../../../examples/olinkserver && cmake --build .
+conan install --build missing . --install-folder ../../build/examples/olinkserver -g=virtualenv && cmake -S . -B ../../build/examples/olinkserver --preset release && cmake --build ../../build/examples/olinkserver
 if [ $? -ne 0 ]; then exit 1; fi;
 popd
-mkdir -p examples/olinkclient;
+mkdir -p build/examples/olinkclient;
 pushd examples/olinkclient;
-conan install --build missing ../../../examples/olinkclient -g=virtualenv && cmake ../../../examples/olinkclient && cmake --build .
+conan install --build missing . --install-folder ../../build/examples/olinkclient -g=virtualenv && cmake -S . -B ../../build/examples/olinkclient --preset release && cmake --build ../../build/examples/olinkclient
 if [ $? -ne 0 ]; then exit 1; fi;
 popd
 {{- end}}


### PR DESCRIPTION
## 📑 Description
The conan test script just called plain cmake for the examples without specifying which compiler configuration to use. This fix re-uses the default config used to build the other modules.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed
