### PR TITLE
fix(apigear): fix high load issue

### DIFF
--- a/goldenmaster/apigear/olink/olinkhost.cpp
+++ b/goldenmaster/apigear/olink/olinkhost.cpp
@@ -51,6 +51,9 @@ void OLinkHost::listen(int port)
 void OLinkHost::close()
 {
     m_connectionStorage.closeConnections();
-    m_webserver->stop();
+    if (m_webserver)
+    {
+        m_webserver->stop();
+    }
     AG_LOG_INFO("wss.closed()");
 }

--- a/goldenmaster/apigear/olink/private/isocketuser.h
+++ b/goldenmaster/apigear/olink/private/isocketuser.h
@@ -20,6 +20,11 @@ public:
     * A callback to inform the socket user that connection was closed with close frame received from network.
     */
     virtual void onConnectionClosedFromNetwork() = 0;
+
+    /** 
+    * A callback to inform that socket is not available to use and messages cannot be sent.
+    */
+    virtual void onNotifyNoSocket() {};
 };
 
 }}   //namespace ApiGear::PocoImpl

--- a/goldenmaster/apigear/olink/private/olinkremote.cpp
+++ b/goldenmaster/apigear/olink/private/olinkremote.cpp
@@ -18,13 +18,13 @@ OLinkRemote::OLinkRemote(std::unique_ptr<Poco::Net::WebSocket> socket,
                         IConnectionStorage& connectionStorage,
                         ApiGear::ObjectLink::RemoteRegistry& registry,
                         const ApiGear::ObjectLink::WriteLogFunc& logFunc)
-    : m_socket(*this),
+    : m_socket(*this, false),
      m_connectionStorage(connectionStorage),
      m_node(ApiGear::ObjectLink::RemoteNode::createRemoteNode(registry))
 {
     m_node->onLog(logFunc);
-    m_node->onWrite([this](std::string msg) {
-        m_socket.writeMessage(msg, Poco::Net::WebSocket::FRAME_TEXT);
+    m_node->onWrite([this](const std::string& msg) {
+        m_socket.writeMessageWithQueue(msg);
     });
     m_socket.changeSocket(std::move(socket));
 }

--- a/goldenmaster/apigear/olink/private/socketwrapper.cpp
+++ b/goldenmaster/apigear/olink/private/socketwrapper.cpp
@@ -2,6 +2,7 @@
 #include "private/isocketuser.h"
 #include "../utilities/logger.h"
 
+#include <Poco/Util/TimerTaskAdapter.h>
 #include <Poco/Net/WebSocket.h>
 #include "Poco/Buffer.h"
 #include "Poco/Exception.h"
@@ -11,16 +12,26 @@
 namespace
 {
     const std::string closeFramePayload = "bye";
+    const std::string pingFramePayload = "ping";
+    long retryInterval = 500; //Milliseconds
+    long smallDelay = 7; //Milliseconds
+    uint32_t messagesToSendAtOnce = 400;
 }
 
 
 namespace ApiGear {
 namespace PocoImpl {
 
-SocketWrapper::SocketWrapper(ISocketUser& socketUser)
+SocketWrapper::SocketWrapper(ISocketUser& socketUser, bool sendPing)
     : m_socketUser(socketUser),
+    m_addPingMessage(sendPing),
     m_disconnectRequested(false)
 {
+}
+
+SocketWrapper::~SocketWrapper()
+{
+    close();
 }
 
 void SocketWrapper::startReceiving()
@@ -58,14 +69,14 @@ void SocketWrapper::startReceiving()
             AG_LOG_ERROR("connection closed with exception: "+ std::string(e.what()));
         }
     } while (!closedFromNetwork && !m_disconnectRequested);
-    if (closedFromNetwork)
-    {
+
+    if (closedFromNetwork){
         onClosed();
         m_socketUser.onConnectionClosedFromNetwork();
     }
 }
 
-bool SocketWrapper::writeMessage(std::string message, int frameOpCode)
+bool SocketWrapper::writeMessage(const std::string& message, int frameOpCode)
 {
     bool succeed = false;
     try {
@@ -82,6 +93,14 @@ bool SocketWrapper::writeMessage(std::string message, int frameOpCode)
     return succeed;
 }
 
+void SocketWrapper::writeMessageWithQueue(const std::string& msg)
+{
+    std::unique_lock<std::timed_mutex> lock(m_queueMutex);
+    m_queue.push_back(msg);
+    lock.unlock();
+    scheduleProcessMessages(smallDelay);
+}
+
 bool SocketWrapper::isClosed() const
 {
     return m_socket == nullptr || m_disconnectRequested;
@@ -89,6 +108,7 @@ bool SocketWrapper::isClosed() const
 
 void SocketWrapper::close()
 {
+    closeQueue();
     m_disconnectRequested = true;
     if (m_receivingDone.valid()){
         m_receivingDone.wait();
@@ -109,8 +129,14 @@ void SocketWrapper::onClosed()
 
 std::unique_ptr<Poco::Net::WebSocket> SocketWrapper::changeSocket(std::unique_ptr<Poco::Net::WebSocket> otherSocket)
 {
+    if (m_processMessagesTask) {
+    std::unique_lock<std::timed_mutex> lock(m_taskMutex);
+    m_processMessagesTask->cancel();
+    m_processMessagesTask.reset();
+    lock.unlock();
+}
     m_disconnectRequested = true;
-    if (m_receivingDone.valid()){
+    if (m_socket && m_receivingDone.valid()){
         m_receivingDone.wait();
     }
     std::unique_lock<std::timed_mutex> lock(m_socketMutex);
@@ -119,10 +145,97 @@ std::unique_ptr<Poco::Net::WebSocket> SocketWrapper::changeSocket(std::unique_pt
     if (m_socket){
         // Common default maximum frame size is 1Mb
         m_socket->setMaxPayloadSize(1048576);
+        std::future<void> other;
+        std::swap(m_receivingDone, other);
         m_receivingDone = std::async(std::launch::async, [this](){startReceiving(); });
+        scheduleProcessMessages(smallDelay);
     }
     m_disconnectRequested = false;
     return otherSocket;
+}
+
+void SocketWrapper::closeQueue()
+{
+    if (m_processMessagesTask) {
+        std::unique_lock<std::timed_mutex> lock(m_taskMutex);
+        m_processMessagesTask->cancel();
+        m_processMessagesTask.reset();
+        lock.unlock();
+    }
+    flushMessages();
+}
+
+
+void SocketWrapper::scheduleProcessMessages(long delayMiliseconds)
+{
+    std::unique_lock<std::timed_mutex> lock(m_taskMutex, std::defer_lock);
+    if (lock.try_lock()) // else other thread is scheduling a task currently, so the messages would be sent anyway.
+    {
+        if (!m_processMessagesTask) {
+            m_processMessagesTask = new Poco::Util::TimerTaskAdapter<SocketWrapper>(*this, &SocketWrapper::processMessages);
+            m_retryTimer.schedule(m_processMessagesTask, delayMiliseconds, retryInterval);
+            lock.unlock();
+        }
+    }
+}
+
+void SocketWrapper::processMessages(Poco::Util::TimerTask& /*task*/)
+{
+    if (isClosed()) {
+        m_socketUser.onNotifyNoSocket();
+        return;
+    }
+    if (m_addPingMessage) {
+        writeMessage(pingFramePayload, Poco::Net::WebSocket::FRAME_OP_PING);
+    }
+    flushMessages();
+
+    std::unique_lock<std::timed_mutex> lock(m_taskMutex);
+    m_processMessagesTask->cancel();
+    m_processMessagesTask.reset();
+    lock.unlock();
+    if (!m_queue.empty()){
+        scheduleProcessMessages(smallDelay);
+    }
+}
+
+void SocketWrapper::flushMessages()
+{
+    if (m_socket)
+    {
+        std::deque<std::string> copyQueue;
+
+        std::unique_lock<std::timed_mutex> lock(m_queueMutex);
+        if (m_queue.size() > messagesToSendAtOnce && !isClosed()){
+            copyQueue.insert(copyQueue.begin(), m_queue.begin(), m_queue.begin() + (messagesToSendAtOnce-1));
+            m_queue.erase(m_queue.begin(), m_queue.begin() + (messagesToSendAtOnce - 1));
+            lock.unlock();
+        } else {
+            std::swap(copyQueue, m_queue);
+            lock.unlock();
+        }
+
+        while (!copyQueue.empty()) {
+            auto message = copyQueue.front();
+            const static std::string log = "write message to socket ";
+            AG_LOG_DEBUG(log);
+            AG_LOG_DEBUG(message);
+            // if we are using JSON we need to use txt message otherwise binary messages
+            auto messageSent = writeMessage(message, Poco::Net::WebSocket::FRAME_TEXT);
+            if (messageSent) {
+                copyQueue.pop_front();
+            }
+            else {
+                if (!isClosed()) {
+                    lock.lock();
+                    // push again not sent elements to queue front 
+                    m_queue.insert(m_queue.begin(), copyQueue.begin(), copyQueue.end());
+                    lock.unlock();
+                }
+                break;
+            }
+        }
+    }
 }
 
 }}   //namespace ApiGear::PocoImpl

--- a/templates/apigear/olink/olinkhost.cpp
+++ b/templates/apigear/olink/olinkhost.cpp
@@ -51,6 +51,9 @@ void OLinkHost::listen(int port)
 void OLinkHost::close()
 {
     m_connectionStorage.closeConnections();
-    m_webserver->stop();
+    if (m_webserver)
+    {
+        m_webserver->stop();
+    }
     AG_LOG_INFO("wss.closed()");
 }

--- a/templates/apigear/olink/private/isocketuser.h
+++ b/templates/apigear/olink/private/isocketuser.h
@@ -20,6 +20,11 @@ public:
     * A callback to inform the socket user that connection was closed with close frame received from network.
     */
     virtual void onConnectionClosedFromNetwork() = 0;
+
+    /** 
+    * A callback to inform that socket is not available to use and messages cannot be sent.
+    */
+    virtual void onNotifyNoSocket() {};
 };
 
 }}   //namespace ApiGear::PocoImpl

--- a/templates/apigear/olink/private/olinkremote.cpp
+++ b/templates/apigear/olink/private/olinkremote.cpp
@@ -18,13 +18,13 @@ OLinkRemote::OLinkRemote(std::unique_ptr<Poco::Net::WebSocket> socket,
                         IConnectionStorage& connectionStorage,
                         ApiGear::ObjectLink::RemoteRegistry& registry,
                         const ApiGear::ObjectLink::WriteLogFunc& logFunc)
-    : m_socket(*this),
+    : m_socket(*this, false),
      m_connectionStorage(connectionStorage),
      m_node(ApiGear::ObjectLink::RemoteNode::createRemoteNode(registry))
 {
     m_node->onLog(logFunc);
-    m_node->onWrite([this](std::string msg) {
-        m_socket.writeMessage(msg, Poco::Net::WebSocket::FRAME_TEXT);
+    m_node->onWrite([this](const std::string& msg) {
+        m_socket.writeMessageWithQueue(msg);
     });
     m_socket.changeSocket(std::move(socket));
 }

--- a/templates/apigear/olink/private/socketwrapper.cpp
+++ b/templates/apigear/olink/private/socketwrapper.cpp
@@ -2,6 +2,7 @@
 #include "private/isocketuser.h"
 #include "../utilities/logger.h"
 
+#include <Poco/Util/TimerTaskAdapter.h>
 #include <Poco/Net/WebSocket.h>
 #include "Poco/Buffer.h"
 #include "Poco/Exception.h"
@@ -11,16 +12,26 @@
 namespace
 {
     const std::string closeFramePayload = "bye";
+    const std::string pingFramePayload = "ping";
+    long retryInterval = 500; //Milliseconds
+    long smallDelay = 7; //Milliseconds
+    uint32_t messagesToSendAtOnce = 400;
 }
 
 
 namespace ApiGear {
 namespace PocoImpl {
 
-SocketWrapper::SocketWrapper(ISocketUser& socketUser)
+SocketWrapper::SocketWrapper(ISocketUser& socketUser, bool sendPing)
     : m_socketUser(socketUser),
+    m_addPingMessage(sendPing),
     m_disconnectRequested(false)
 {
+}
+
+SocketWrapper::~SocketWrapper()
+{
+    close();
 }
 
 void SocketWrapper::startReceiving()
@@ -58,14 +69,14 @@ void SocketWrapper::startReceiving()
             AG_LOG_ERROR("connection closed with exception: "+ std::string(e.what()));
         }
     } while (!closedFromNetwork && !m_disconnectRequested);
-    if (closedFromNetwork)
-    {
+
+    if (closedFromNetwork){
         onClosed();
         m_socketUser.onConnectionClosedFromNetwork();
     }
 }
 
-bool SocketWrapper::writeMessage(std::string message, int frameOpCode)
+bool SocketWrapper::writeMessage(const std::string& message, int frameOpCode)
 {
     bool succeed = false;
     try {
@@ -82,6 +93,14 @@ bool SocketWrapper::writeMessage(std::string message, int frameOpCode)
     return succeed;
 }
 
+void SocketWrapper::writeMessageWithQueue(const std::string& msg)
+{
+    std::unique_lock<std::timed_mutex> lock(m_queueMutex);
+    m_queue.push_back(msg);
+    lock.unlock();
+    scheduleProcessMessages(smallDelay);
+}
+
 bool SocketWrapper::isClosed() const
 {
     return m_socket == nullptr || m_disconnectRequested;
@@ -89,6 +108,7 @@ bool SocketWrapper::isClosed() const
 
 void SocketWrapper::close()
 {
+    closeQueue();
     m_disconnectRequested = true;
     if (m_receivingDone.valid()){
         m_receivingDone.wait();
@@ -109,8 +129,14 @@ void SocketWrapper::onClosed()
 
 std::unique_ptr<Poco::Net::WebSocket> SocketWrapper::changeSocket(std::unique_ptr<Poco::Net::WebSocket> otherSocket)
 {
+    if (m_processMessagesTask) {
+    std::unique_lock<std::timed_mutex> lock(m_taskMutex);
+    m_processMessagesTask->cancel();
+    m_processMessagesTask.reset();
+    lock.unlock();
+}
     m_disconnectRequested = true;
-    if (m_receivingDone.valid()){
+    if (m_socket && m_receivingDone.valid()){
         m_receivingDone.wait();
     }
     std::unique_lock<std::timed_mutex> lock(m_socketMutex);
@@ -119,10 +145,97 @@ std::unique_ptr<Poco::Net::WebSocket> SocketWrapper::changeSocket(std::unique_pt
     if (m_socket){
         // Common default maximum frame size is 1Mb
         m_socket->setMaxPayloadSize(1048576);
+        std::future<void> other;
+        std::swap(m_receivingDone, other);
         m_receivingDone = std::async(std::launch::async, [this](){startReceiving(); });
+        scheduleProcessMessages(smallDelay);
     }
     m_disconnectRequested = false;
     return otherSocket;
+}
+
+void SocketWrapper::closeQueue()
+{
+    if (m_processMessagesTask) {
+        std::unique_lock<std::timed_mutex> lock(m_taskMutex);
+        m_processMessagesTask->cancel();
+        m_processMessagesTask.reset();
+        lock.unlock();
+    }
+    flushMessages();
+}
+
+
+void SocketWrapper::scheduleProcessMessages(long delayMiliseconds)
+{
+    std::unique_lock<std::timed_mutex> lock(m_taskMutex, std::defer_lock);
+    if (lock.try_lock()) // else other thread is scheduling a task currently, so the messages would be sent anyway.
+    {
+        if (!m_processMessagesTask) {
+            m_processMessagesTask = new Poco::Util::TimerTaskAdapter<SocketWrapper>(*this, &SocketWrapper::processMessages);
+            m_retryTimer.schedule(m_processMessagesTask, delayMiliseconds, retryInterval);
+            lock.unlock();
+        }
+    }
+}
+
+void SocketWrapper::processMessages(Poco::Util::TimerTask& /*task*/)
+{
+    if (isClosed()) {
+        m_socketUser.onNotifyNoSocket();
+        return;
+    }
+    if (m_addPingMessage) {
+        writeMessage(pingFramePayload, Poco::Net::WebSocket::FRAME_OP_PING);
+    }
+    flushMessages();
+
+    std::unique_lock<std::timed_mutex> lock(m_taskMutex);
+    m_processMessagesTask->cancel();
+    m_processMessagesTask.reset();
+    lock.unlock();
+    if (!m_queue.empty()){
+        scheduleProcessMessages(smallDelay);
+    }
+}
+
+void SocketWrapper::flushMessages()
+{
+    if (m_socket)
+    {
+        std::deque<std::string> copyQueue;
+
+        std::unique_lock<std::timed_mutex> lock(m_queueMutex);
+        if (m_queue.size() > messagesToSendAtOnce && !isClosed()){
+            copyQueue.insert(copyQueue.begin(), m_queue.begin(), m_queue.begin() + (messagesToSendAtOnce-1));
+            m_queue.erase(m_queue.begin(), m_queue.begin() + (messagesToSendAtOnce - 1));
+            lock.unlock();
+        } else {
+            std::swap(copyQueue, m_queue);
+            lock.unlock();
+        }
+
+        while (!copyQueue.empty()) {
+            auto message = copyQueue.front();
+            const static std::string log = "write message to socket ";
+            AG_LOG_DEBUG(log);
+            AG_LOG_DEBUG(message);
+            // if we are using JSON we need to use txt message otherwise binary messages
+            auto messageSent = writeMessage(message, Poco::Net::WebSocket::FRAME_TEXT);
+            if (messageSent) {
+                copyQueue.pop_front();
+            }
+            else {
+                if (!isClosed()) {
+                    lock.lock();
+                    // push again not sent elements to queue front 
+                    m_queue.insert(m_queue.begin(), copyQueue.begin(), copyQueue.end());
+                    lock.unlock();
+                }
+                break;
+            }
+        }
+    }
 }
 
 }}   //namespace ApiGear::PocoImpl


### PR DESCRIPTION
during high load test (sending at once 1000 messages from each of 100 threads the pair of test applications for server and client got stuck. Most probable rootcause was too high load on sending messages by server. solution:
1. moved a queue from client side only to socket wrapper now it is used for both server and client.
2. changes the time for scheduling task to some smaller number - 7, cause 5was too lit
3. limit the number of messages sent in each loop to 400 - then schedule a next task for sending - this way it is unblocked and may receive message

created bug report for better fix:
https://github.com/apigear-io/template-cpp14/issues/98
also a bug report for sending ping message:
https://github.com/apigear-io/template-cpp14/issues/96

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
