### PR TITLE
fix(examples):fix generate olink_example feature

### DIFF
--- a/templates/CMakeLists.txt.tpl
+++ b/templates/CMakeLists.txt.tpl
@@ -51,7 +51,7 @@ endif()
 add_subdirectory(examples/app)
 add_subdirectory(examples/appthreadsafe)
 {{- end }}
-{{- if .Features.examples }}
+{{- if .Features.examples_olink }}
 add_subdirectory(examples/olinkserver)
 add_subdirectory(examples/olinkclient)
 {{- end }}


### PR DESCRIPTION
in cmake adding subdirectory for olink exapmles was done for wrong feature, now it is added if olink_example feature is on

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->