### PR TITLE
align to new olink core

### DIFF
--- a/goldenmaster/apigear/olink/CMakeLists.txt
+++ b/goldenmaster/apigear/olink/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT objectlink-core-cpp_FOUND)
   message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
   FetchContent_Declare(olink-core
       GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.6
+      GIT_TAG "dphan/extracting-protocol-format"
       GIT_SHALLOW TRUE
       EXCLUDE_FROM_ALL FALSE
   )

--- a/goldenmaster/apigear/olink/tests/olink_connection.test.cpp
+++ b/goldenmaster/apigear/olink/tests/olink_connection.test.cpp
@@ -64,6 +64,16 @@ namespace {
            != container.end();
     }
 
+    std::string propert1Name = "property1";
+    std::string propert2Name = "property2";
+    std::string propert3Name = "property3";
+    std::string stringValue1 = "someString1";
+    int someIntValue1 = 91;
+    bool boolFalse = false;
+
+    auto initProperties = ApiGear::ObjectLink::argumentsToContent(ApiGear::ObjectLink::toInitialProperty(propert1Name, stringValue1),
+        ApiGear::ObjectLink::toInitialProperty(propert2Name, someIntValue1),
+        ApiGear::ObjectLink::toInitialProperty(propert3Name, boolFalse));
 }
 
 TEST_CASE("OlinkConnection tests")
@@ -96,7 +106,6 @@ TEST_CASE("OlinkConnection tests")
         REQUIRE(msgs[0].flags == Poco::Net::WebSocket::FRAME_TEXT);
         
         // Send init message from server and check it is delivered and decoded
-        nlohmann::json initProperties = { {"property1", "some_string" }, { "property2",  9 }, { "property3", false } };
         REQUIRE_CALL(*sink1, olinkOnInit(sink1Id, initProperties, testOlinkConnection->node().get()));
         
         auto preparedInitMessage = converter.toString(ApiGear::ObjectLink::Protocol::initMessage(sink1Id, initProperties));
@@ -143,7 +152,6 @@ TEST_CASE("OlinkConnection tests")
         REQUIRE(registry.getNode(sink1Id).lock() == testOlinkConnection->node());
 
         // Send from server init message
-        nlohmann::json initProperties = { {"property1", "some_string" }, { "property2",  9 }, { "property3", false } };
         REQUIRE_CALL(*sink1, olinkOnInit(sink1Id, initProperties, testOlinkConnection->node().get()));
         auto preparedInitMessage = converter.toString(ApiGear::ObjectLink::Protocol::initMessage(sink1Id, initProperties));
         server.sendFrame(preparedInitMessage);
@@ -274,7 +282,6 @@ TEST_CASE("OlinkConnection tests")
         REQUIRE(msgs[0].flags == Poco::Net::WebSocket::FRAME_TEXT);
 
         // Send init message from server and check it is delivered and decoded
-        nlohmann::json initProperties = { {"property1", "some_string" }, { "property2",  9 }, { "property3", false } };
         REQUIRE_CALL(*sink1, olinkOnInit(sink1Id, initProperties, testOlinkConnection->node().get()));
 
         auto preparedInitMessage = converter.toString(ApiGear::ObjectLink::Protocol::initMessage(sink1Id, initProperties));

--- a/goldenmaster/apigear/olink/tests/olinkhost.test.cpp
+++ b/goldenmaster/apigear/olink/tests/olinkhost.test.cpp
@@ -53,8 +53,22 @@ namespace {
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/ws", Poco::Net::HTTPRequest::HTTP_1_1);
         Poco::Net::HTTPResponse response;
 
-        nlohmann::json initProperties1 = { {"property1", "some_string1" }, { "property2",  92 }, { "property3", true } };
-        nlohmann::json initProperties2 = { {"property1", "some_string2" }, { "property2",  29 }, { "property3", false } };
+        std::string propert1Name = "property1";
+        std::string propert2Name = "property2";
+        std::string propert3Name = "property3";
+        std::string stringValue1 = "someString1";
+        std::string stringValue2 = "someString2";
+        int someIntValue1 = 91;
+        int someIntValue2 = 19;
+        bool boolFalse = false;
+        bool boolTrue = true;
+
+        auto initProperties1 = ApiGear::ObjectLink::argumentsToContent(ApiGear::ObjectLink::toInitialProperty(propert1Name, stringValue1),
+            ApiGear::ObjectLink::toInitialProperty( propert2Name,  someIntValue1),
+            ApiGear::ObjectLink::toInitialProperty( propert3Name, boolTrue ));
+        auto initProperties2 = ApiGear::ObjectLink::argumentsToContent(ApiGear::ObjectLink::toInitialProperty(propert1Name, stringValue2),
+            ApiGear::ObjectLink::toInitialProperty( propert2Name,  someIntValue2),
+            ApiGear::ObjectLink::toInitialProperty( propert3Name, boolFalse));
 
         std::string any_payload = "any";
 

--- a/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceclient.cpp
+++ b/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "tb_enum/generated/core/tb_enum.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbEnum;
@@ -19,35 +20,27 @@ EnumInterfaceClient::EnumInterfaceClient()
     : m_publisher(std::make_unique<EnumInterfacePublisher>())
 {}
 
-void EnumInterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("prop0")) {
-        setProp0Local(fields["prop0"].get<Enum0Enum>());
-    }
-    if(fields.contains("prop1")) {
-        setProp1Local(fields["prop1"].get<Enum1Enum>());
-    }
-    if(fields.contains("prop2")) {
-        setProp2Local(fields["prop2"].get<Enum2Enum>());
-    }
-    if(fields.contains("prop3")) {
-        setProp3Local(fields["prop3"].get<Enum3Enum>());
-    }
-}
-
-void EnumInterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void EnumInterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "prop0") {
-        setProp0Local(value.get<Enum0Enum>());
+        Enum0Enum value_prop0 {};
+        readValue(value, value_prop0);
+        setProp0Local(value_prop0);
     }
     else if ( propertyName == "prop1") {
-        setProp1Local(value.get<Enum1Enum>());
+        Enum1Enum value_prop1 {};
+        readValue(value, value_prop1);
+        setProp1Local(value_prop1);
     }
     else if ( propertyName == "prop2") {
-        setProp2Local(value.get<Enum2Enum>());
+        Enum2Enum value_prop2 {};
+        readValue(value, value_prop2);
+        setProp2Local(value_prop2);
     }
     else if ( propertyName == "prop3") {
-        setProp3Local(value.get<Enum3Enum>());
+        Enum3Enum value_prop3 {};
+        readValue(value, value_prop3);
+        setProp3Local(value_prop3);
     }
 }
 
@@ -58,7 +51,7 @@ void EnumInterfaceClient::setProp0(Enum0Enum prop0)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop0");
-    m_node->setRemoteProperty(propertyId, prop0);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop0));
 }
 
 void EnumInterfaceClient::setProp0Local(Enum0Enum prop0)
@@ -81,7 +74,7 @@ void EnumInterfaceClient::setProp1(Enum1Enum prop1)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    m_node->setRemoteProperty(propertyId, prop1);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
 }
 
 void EnumInterfaceClient::setProp1Local(Enum1Enum prop1)
@@ -104,7 +97,7 @@ void EnumInterfaceClient::setProp2(Enum2Enum prop2)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    m_node->setRemoteProperty(propertyId, prop2);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop2));
 }
 
 void EnumInterfaceClient::setProp2Local(Enum2Enum prop2)
@@ -127,7 +120,7 @@ void EnumInterfaceClient::setProp3(Enum3Enum prop3)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
-    m_node->setRemoteProperty(propertyId, prop3);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop3));
 }
 
 void EnumInterfaceClient::setProp3Local(Enum3Enum prop3)
@@ -164,10 +157,12 @@ std::future<Enum0Enum> EnumInterfaceClient::func0Async(Enum0Enum param0)
         {
             std::promise<Enum0Enum> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func0");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param0}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Enum0Enum& value = arg.value.get<Enum0Enum>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param0 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Enum0Enum result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -195,10 +190,12 @@ std::future<Enum1Enum> EnumInterfaceClient::func1Async(Enum1Enum param1)
         {
             std::promise<Enum1Enum> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Enum1Enum& value = arg.value.get<Enum1Enum>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Enum1Enum result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -226,10 +223,12 @@ std::future<Enum2Enum> EnumInterfaceClient::func2Async(Enum2Enum param2)
         {
             std::promise<Enum2Enum> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Enum2Enum& value = arg.value.get<Enum2Enum>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param2 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Enum2Enum result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -257,10 +256,12 @@ std::future<Enum3Enum> EnumInterfaceClient::func3Async(Enum3Enum param3)
         {
             std::promise<Enum3Enum> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func3");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param3}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Enum3Enum& value = arg.value.get<Enum3Enum>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param3 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Enum3Enum result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -272,35 +273,43 @@ std::string EnumInterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void EnumInterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void EnumInterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sig0") {
-        m_publisher->publishSig0(args[0].get<Enum0Enum>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sig0") {Enum0Enum arg_param0 {};
+        argumentsReader.read(arg_param0);m_publisher->publishSig0(arg_param0);   
         return;
     }
-    if(signalName == "sig1") {
-        m_publisher->publishSig1(args[0].get<Enum1Enum>());   
+    if(signalName == "sig1") {Enum1Enum arg_param1 {};
+        argumentsReader.read(arg_param1);m_publisher->publishSig1(arg_param1);   
         return;
     }
-    if(signalName == "sig2") {
-        m_publisher->publishSig2(args[0].get<Enum2Enum>());   
+    if(signalName == "sig2") {Enum2Enum arg_param2 {};
+        argumentsReader.read(arg_param2);m_publisher->publishSig2(arg_param2);   
         return;
     }
-    if(signalName == "sig3") {
-        m_publisher->publishSig3(args[0].get<Enum3Enum>());   
+    if(signalName == "sig3") {Enum3Enum arg_param3 {};
+        argumentsReader.read(arg_param3);m_publisher->publishSig3(arg_param3);   
         return;
     }
 }
 
-void EnumInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void EnumInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void EnumInterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void EnumInterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void EnumInterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceclient.h
+++ b/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceclient.h
@@ -137,21 +137,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the EnumInterface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -159,16 +159,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from EnumInterface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop0 and informs subscriber about the change*/
     void setProp0Local(Enum0Enum prop0);
     /**  Updates local value for Prop1 and informs subscriber about the change*/

--- a/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceservice.cpp
+++ b/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceservice.cpp
@@ -6,6 +6,7 @@
 
 #include "olink/iremotenode.h"
 #include "olink/remoteregistry.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 #include <iostream>
@@ -35,50 +36,55 @@ std::string EnumInterfaceService::olinkObjectName() {
     return interfaceId;
 }
 
-nlohmann::json EnumInterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+ApiGear::ObjectLink::OLinkContent EnumInterfaceService::olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& fcnArgs) {
     AG_LOG_DEBUG("EnumInterfaceService invoke " + methodId);
     const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(fcnArgs);
     if(memberMethod == "func0") {
-        const Enum0Enum& param0 = fcnArgs.at(0);
-        Enum0Enum result = m_EnumInterface->func0(param0);
-        return result;
+        Enum0Enum param0{};
+        argumentsReader.read(param0);
+        return ApiGear::ObjectLink::invokeReturnValue(m_EnumInterface->func0(param0));
     }
     if(memberMethod == "func1") {
-        const Enum1Enum& param1 = fcnArgs.at(0);
-        Enum1Enum result = m_EnumInterface->func1(param1);
-        return result;
+        Enum1Enum param1{};
+        argumentsReader.read(param1);
+        return ApiGear::ObjectLink::invokeReturnValue(m_EnumInterface->func1(param1));
     }
     if(memberMethod == "func2") {
-        const Enum2Enum& param2 = fcnArgs.at(0);
-        Enum2Enum result = m_EnumInterface->func2(param2);
-        return result;
+        Enum2Enum param2{};
+        argumentsReader.read(param2);
+        return ApiGear::ObjectLink::invokeReturnValue(m_EnumInterface->func2(param2));
     }
     if(memberMethod == "func3") {
-        const Enum3Enum& param3 = fcnArgs.at(0);
-        Enum3Enum result = m_EnumInterface->func3(param3);
-        return result;
+        Enum3Enum param3{};
+        argumentsReader.read(param3);
+        return ApiGear::ObjectLink::invokeReturnValue(m_EnumInterface->func3(param3));
     }
-    return nlohmann::json();
+    return {};
 }
 
-void EnumInterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+void EnumInterfaceService::olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) {
     AG_LOG_DEBUG("EnumInterfaceService set property " + propertyId);
     const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
     if(memberProperty == "prop0") {
-        Enum0Enum prop0 = value.get<Enum0Enum>();
-        m_EnumInterface->setProp0(prop0);
+        Enum0Enum value_prop0{};
+        ApiGear::ObjectLink::readValue(value, value_prop0);
+        m_EnumInterface->setProp0(value_prop0);
     }
     if(memberProperty == "prop1") {
-        Enum1Enum prop1 = value.get<Enum1Enum>();
-        m_EnumInterface->setProp1(prop1);
+        Enum1Enum value_prop1{};
+        ApiGear::ObjectLink::readValue(value, value_prop1);
+        m_EnumInterface->setProp1(value_prop1);
     }
     if(memberProperty == "prop2") {
-        Enum2Enum prop2 = value.get<Enum2Enum>();
-        m_EnumInterface->setProp2(prop2);
+        Enum2Enum value_prop2{};
+        ApiGear::ObjectLink::readValue(value, value_prop2);
+        m_EnumInterface->setProp2(value_prop2);
     }
     if(memberProperty == "prop3") {
-        Enum3Enum prop3 = value.get<Enum3Enum>();
-        m_EnumInterface->setProp3(prop3);
+        Enum3Enum value_prop3{};
+        ApiGear::ObjectLink::readValue(value, value_prop3);
+        m_EnumInterface->setProp3(value_prop3);
     } 
 }
 
@@ -90,18 +96,17 @@ void EnumInterfaceService::olinkUnlinked(const std::string& objectId){
     AG_LOG_DEBUG("EnumInterfaceService unlinked " + objectId);
 }
 
-nlohmann::json EnumInterfaceService::olinkCollectProperties()
+ApiGear::ObjectLink::OLinkContent EnumInterfaceService::olinkCollectProperties()
 {
-    return nlohmann::json::object({
-        { "prop0", m_EnumInterface->getProp0() },
-        { "prop1", m_EnumInterface->getProp1() },
-        { "prop2", m_EnumInterface->getProp2() },
-        { "prop3", m_EnumInterface->getProp3() }
-    });
+    return ApiGear::ObjectLink::argumentsToContent(
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop0"), m_EnumInterface->getProp0()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop1"), m_EnumInterface->getProp1()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop2"), m_EnumInterface->getProp2()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop3"), m_EnumInterface->getProp3()) );
 }
 void EnumInterfaceService::onSig0(Enum0Enum param0)
 {
-    const nlohmann::json args = { param0 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param0);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig0");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -113,7 +118,7 @@ void EnumInterfaceService::onSig0(Enum0Enum param0)
 }
 void EnumInterfaceService::onSig1(Enum1Enum param1)
 {
-    const nlohmann::json args = { param1 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -125,7 +130,7 @@ void EnumInterfaceService::onSig1(Enum1Enum param1)
 }
 void EnumInterfaceService::onSig2(Enum2Enum param2)
 {
-    const nlohmann::json args = { param2 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param2);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -137,7 +142,7 @@ void EnumInterfaceService::onSig2(Enum2Enum param2)
 }
 void EnumInterfaceService::onSig3(Enum3Enum param3)
 {
-    const nlohmann::json args = { param3 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param3);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig3");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -154,7 +159,7 @@ void EnumInterfaceService::onProp0Changed(Enum0Enum prop0)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop0);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop0));
         }
     }
 }
@@ -165,7 +170,7 @@ void EnumInterfaceService::onProp1Changed(Enum1Enum prop1)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop1);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
         }
     }
 }
@@ -176,7 +181,7 @@ void EnumInterfaceService::onProp2Changed(Enum2Enum prop2)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop2);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop2));
         }
     }
 }
@@ -187,7 +192,7 @@ void EnumInterfaceService::onProp3Changed(Enum3Enum prop3)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop3);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop3));
         }
     }
 }

--- a/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceservice.h
+++ b/goldenmaster/modules/tb_enum_module/tb_enum/generated/olink/enuminterfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to EnumInterface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of EnumInterface object.
     * @return the set of properties with their current values for the EnumInterface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig0 through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum1interfaceclient.h
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum1interfaceclient.h
@@ -80,21 +80,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the SameEnum1Interface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -102,16 +102,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from SameEnum1Interface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop1 and informs subscriber about the change*/
     void setProp1Local(Enum1Enum prop1);
 

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum1interfaceservice.h
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum1interfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to SameEnum1Interface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of SameEnum1Interface object.
     * @return the set of properties with their current values for the SameEnum1Interface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig1 through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum2interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum2interfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "tb_same1/generated/core/tb_same1.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame1;
@@ -19,23 +20,17 @@ SameEnum2InterfaceClient::SameEnum2InterfaceClient()
     : m_publisher(std::make_unique<SameEnum2InterfacePublisher>())
 {}
 
-void SameEnum2InterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("prop1")) {
-        setProp1Local(fields["prop1"].get<Enum1Enum>());
-    }
-    if(fields.contains("prop2")) {
-        setProp2Local(fields["prop2"].get<Enum2Enum>());
-    }
-}
-
-void SameEnum2InterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void SameEnum2InterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "prop1") {
-        setProp1Local(value.get<Enum1Enum>());
+        Enum1Enum value_prop1 {};
+        readValue(value, value_prop1);
+        setProp1Local(value_prop1);
     }
     else if ( propertyName == "prop2") {
-        setProp2Local(value.get<Enum2Enum>());
+        Enum2Enum value_prop2 {};
+        readValue(value, value_prop2);
+        setProp2Local(value_prop2);
     }
 }
 
@@ -46,7 +41,7 @@ void SameEnum2InterfaceClient::setProp1(Enum1Enum prop1)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    m_node->setRemoteProperty(propertyId, prop1);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
 }
 
 void SameEnum2InterfaceClient::setProp1Local(Enum1Enum prop1)
@@ -69,7 +64,7 @@ void SameEnum2InterfaceClient::setProp2(Enum2Enum prop2)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    m_node->setRemoteProperty(propertyId, prop2);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop2));
 }
 
 void SameEnum2InterfaceClient::setProp2Local(Enum2Enum prop2)
@@ -106,10 +101,12 @@ std::future<Enum1Enum> SameEnum2InterfaceClient::func1Async(Enum1Enum param1)
         {
             std::promise<Enum1Enum> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Enum1Enum& value = arg.value.get<Enum1Enum>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Enum1Enum result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -138,10 +135,12 @@ std::future<Enum1Enum> SameEnum2InterfaceClient::func2Async(Enum1Enum param1, En
         {
             std::promise<Enum1Enum> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Enum1Enum& value = arg.value.get<Enum1Enum>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1, param2 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Enum1Enum result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -153,27 +152,36 @@ std::string SameEnum2InterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void SameEnum2InterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void SameEnum2InterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sig1") {
-        m_publisher->publishSig1(args[0].get<Enum1Enum>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sig1") {Enum1Enum arg_param1 {};
+        argumentsReader.read(arg_param1);m_publisher->publishSig1(arg_param1);   
         return;
     }
-    if(signalName == "sig2") {
-        m_publisher->publishSig2(args[0].get<Enum1Enum>(),args[1].get<Enum2Enum>());   
+    if(signalName == "sig2") {Enum1Enum arg_param1 {};
+        argumentsReader.read(arg_param1);Enum2Enum arg_param2 {};
+        argumentsReader.read(arg_param2);m_publisher->publishSig2(arg_param1,arg_param2);   
         return;
     }
 }
 
-void SameEnum2InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void SameEnum2InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void SameEnum2InterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void SameEnum2InterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void SameEnum2InterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum2interfaceclient.h
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum2interfaceclient.h
@@ -99,21 +99,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the SameEnum2Interface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -121,16 +121,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from SameEnum2Interface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop1 and informs subscriber about the change*/
     void setProp1Local(Enum1Enum prop1);
     /**  Updates local value for Prop2 and informs subscriber about the change*/

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum2interfaceservice.h
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/sameenum2interfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to SameEnum2Interface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of SameEnum2Interface object.
     * @return the set of properties with their current values for the SameEnum2Interface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig1 through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "tb_same1/generated/core/tb_same1.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame1;
@@ -19,17 +20,12 @@ SameStruct1InterfaceClient::SameStruct1InterfaceClient()
     : m_publisher(std::make_unique<SameStruct1InterfacePublisher>())
 {}
 
-void SameStruct1InterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("prop1")) {
-        setProp1Local(fields["prop1"].get<Struct1>());
-    }
-}
-
-void SameStruct1InterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void SameStruct1InterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "prop1") {
-        setProp1Local(value.get<Struct1>());
+        Struct1 value_prop1 {};
+        readValue(value, value_prop1);
+        setProp1Local(value_prop1);
     }
 }
 
@@ -40,7 +36,7 @@ void SameStruct1InterfaceClient::setProp1(const Struct1& prop1)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    m_node->setRemoteProperty(propertyId, prop1);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
 }
 
 void SameStruct1InterfaceClient::setProp1Local(const Struct1& prop1)
@@ -77,10 +73,12 @@ std::future<Struct1> SameStruct1InterfaceClient::func1Async(const Struct1& param
         {
             std::promise<Struct1> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Struct1& value = arg.value.get<Struct1>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Struct1 result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -92,23 +90,31 @@ std::string SameStruct1InterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void SameStruct1InterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void SameStruct1InterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sig1") {
-        m_publisher->publishSig1(args[0].get<Struct1>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sig1") {Struct1 arg_param1 {};
+        argumentsReader.read(arg_param1);m_publisher->publishSig1(arg_param1);   
         return;
     }
 }
 
-void SameStruct1InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void SameStruct1InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void SameStruct1InterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void SameStruct1InterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void SameStruct1InterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceclient.h
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceclient.h
@@ -80,21 +80,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the SameStruct1Interface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -102,16 +102,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from SameStruct1Interface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop1 and informs subscriber about the change*/
     void setProp1Local(const Struct1& prop1);
 

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceservice.cpp
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceservice.cpp
@@ -6,6 +6,7 @@
 
 #include "olink/iremotenode.h"
 #include "olink/remoteregistry.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 #include <iostream>
@@ -35,23 +36,25 @@ std::string SameStruct1InterfaceService::olinkObjectName() {
     return interfaceId;
 }
 
-nlohmann::json SameStruct1InterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+ApiGear::ObjectLink::OLinkContent SameStruct1InterfaceService::olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& fcnArgs) {
     AG_LOG_DEBUG("SameStruct1InterfaceService invoke " + methodId);
     const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(fcnArgs);
     if(memberMethod == "func1") {
-        const Struct1& param1 = fcnArgs.at(0);
-        Struct1 result = m_SameStruct1Interface->func1(param1);
-        return result;
+        Struct1 param1{};
+        argumentsReader.read(param1);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SameStruct1Interface->func1(param1));
     }
-    return nlohmann::json();
+    return {};
 }
 
-void SameStruct1InterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+void SameStruct1InterfaceService::olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) {
     AG_LOG_DEBUG("SameStruct1InterfaceService set property " + propertyId);
     const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
     if(memberProperty == "prop1") {
-        Struct1 prop1 = value.get<Struct1>();
-        m_SameStruct1Interface->setProp1(prop1);
+        Struct1 value_prop1{};
+        ApiGear::ObjectLink::readValue(value, value_prop1);
+        m_SameStruct1Interface->setProp1(value_prop1);
     } 
 }
 
@@ -63,15 +66,14 @@ void SameStruct1InterfaceService::olinkUnlinked(const std::string& objectId){
     AG_LOG_DEBUG("SameStruct1InterfaceService unlinked " + objectId);
 }
 
-nlohmann::json SameStruct1InterfaceService::olinkCollectProperties()
+ApiGear::ObjectLink::OLinkContent SameStruct1InterfaceService::olinkCollectProperties()
 {
-    return nlohmann::json::object({
-        { "prop1", m_SameStruct1Interface->getProp1() }
-    });
+    return ApiGear::ObjectLink::argumentsToContent(
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop1"), m_SameStruct1Interface->getProp1()) );
 }
 void SameStruct1InterfaceService::onSig1(const Struct1& param1)
 {
-    const nlohmann::json args = { param1 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -88,7 +90,7 @@ void SameStruct1InterfaceService::onProp1Changed(const Struct1& prop1)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop1);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
         }
     }
 }

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceservice.h
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct1interfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to SameStruct1Interface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of SameStruct1Interface object.
     * @return the set of properties with their current values for the SameStruct1Interface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig1 through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct2interfaceclient.h
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct2interfaceclient.h
@@ -99,21 +99,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the SameStruct2Interface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -121,16 +121,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from SameStruct2Interface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop1 and informs subscriber about the change*/
     void setProp1Local(const Struct2& prop1);
     /**  Updates local value for Prop2 and informs subscriber about the change*/

--- a/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct2interfaceservice.h
+++ b/goldenmaster/modules/tb_same1_module/tb_same1/generated/olink/samestruct2interfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to SameStruct2Interface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of SameStruct2Interface object.
     * @return the set of properties with their current values for the SameStruct2Interface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig1 through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum1interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum1interfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "tb_same2/generated/core/tb_same2.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame2;
@@ -19,17 +20,12 @@ SameEnum1InterfaceClient::SameEnum1InterfaceClient()
     : m_publisher(std::make_unique<SameEnum1InterfacePublisher>())
 {}
 
-void SameEnum1InterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("prop1")) {
-        setProp1Local(fields["prop1"].get<Enum1Enum>());
-    }
-}
-
-void SameEnum1InterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void SameEnum1InterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "prop1") {
-        setProp1Local(value.get<Enum1Enum>());
+        Enum1Enum value_prop1 {};
+        readValue(value, value_prop1);
+        setProp1Local(value_prop1);
     }
 }
 
@@ -40,7 +36,7 @@ void SameEnum1InterfaceClient::setProp1(Enum1Enum prop1)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    m_node->setRemoteProperty(propertyId, prop1);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
 }
 
 void SameEnum1InterfaceClient::setProp1Local(Enum1Enum prop1)
@@ -77,10 +73,12 @@ std::future<Enum1Enum> SameEnum1InterfaceClient::func1Async(Enum1Enum param1)
         {
             std::promise<Enum1Enum> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Enum1Enum& value = arg.value.get<Enum1Enum>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Enum1Enum result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -92,23 +90,31 @@ std::string SameEnum1InterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void SameEnum1InterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void SameEnum1InterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sig1") {
-        m_publisher->publishSig1(args[0].get<Enum1Enum>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sig1") {Enum1Enum arg_param1 {};
+        argumentsReader.read(arg_param1);m_publisher->publishSig1(arg_param1);   
         return;
     }
 }
 
-void SameEnum1InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void SameEnum1InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void SameEnum1InterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void SameEnum1InterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void SameEnum1InterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum1interfaceclient.h
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum1interfaceclient.h
@@ -80,21 +80,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the SameEnum1Interface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -102,16 +102,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from SameEnum1Interface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop1 and informs subscriber about the change*/
     void setProp1Local(Enum1Enum prop1);
 

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum1interfaceservice.h
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum1interfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to SameEnum1Interface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of SameEnum1Interface object.
     * @return the set of properties with their current values for the SameEnum1Interface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig1 through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum2interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum2interfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "tb_same2/generated/core/tb_same2.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame2;
@@ -19,23 +20,17 @@ SameEnum2InterfaceClient::SameEnum2InterfaceClient()
     : m_publisher(std::make_unique<SameEnum2InterfacePublisher>())
 {}
 
-void SameEnum2InterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("prop1")) {
-        setProp1Local(fields["prop1"].get<Enum1Enum>());
-    }
-    if(fields.contains("prop2")) {
-        setProp2Local(fields["prop2"].get<Enum2Enum>());
-    }
-}
-
-void SameEnum2InterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void SameEnum2InterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "prop1") {
-        setProp1Local(value.get<Enum1Enum>());
+        Enum1Enum value_prop1 {};
+        readValue(value, value_prop1);
+        setProp1Local(value_prop1);
     }
     else if ( propertyName == "prop2") {
-        setProp2Local(value.get<Enum2Enum>());
+        Enum2Enum value_prop2 {};
+        readValue(value, value_prop2);
+        setProp2Local(value_prop2);
     }
 }
 
@@ -46,7 +41,7 @@ void SameEnum2InterfaceClient::setProp1(Enum1Enum prop1)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    m_node->setRemoteProperty(propertyId, prop1);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
 }
 
 void SameEnum2InterfaceClient::setProp1Local(Enum1Enum prop1)
@@ -69,7 +64,7 @@ void SameEnum2InterfaceClient::setProp2(Enum2Enum prop2)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    m_node->setRemoteProperty(propertyId, prop2);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop2));
 }
 
 void SameEnum2InterfaceClient::setProp2Local(Enum2Enum prop2)
@@ -106,10 +101,12 @@ std::future<Enum1Enum> SameEnum2InterfaceClient::func1Async(Enum1Enum param1)
         {
             std::promise<Enum1Enum> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Enum1Enum& value = arg.value.get<Enum1Enum>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Enum1Enum result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -138,10 +135,12 @@ std::future<Enum1Enum> SameEnum2InterfaceClient::func2Async(Enum1Enum param1, En
         {
             std::promise<Enum1Enum> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Enum1Enum& value = arg.value.get<Enum1Enum>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1, param2 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Enum1Enum result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -153,27 +152,36 @@ std::string SameEnum2InterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void SameEnum2InterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void SameEnum2InterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sig1") {
-        m_publisher->publishSig1(args[0].get<Enum1Enum>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sig1") {Enum1Enum arg_param1 {};
+        argumentsReader.read(arg_param1);m_publisher->publishSig1(arg_param1);   
         return;
     }
-    if(signalName == "sig2") {
-        m_publisher->publishSig2(args[0].get<Enum1Enum>(),args[1].get<Enum2Enum>());   
+    if(signalName == "sig2") {Enum1Enum arg_param1 {};
+        argumentsReader.read(arg_param1);Enum2Enum arg_param2 {};
+        argumentsReader.read(arg_param2);m_publisher->publishSig2(arg_param1,arg_param2);   
         return;
     }
 }
 
-void SameEnum2InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void SameEnum2InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void SameEnum2InterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void SameEnum2InterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void SameEnum2InterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum2interfaceclient.h
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum2interfaceclient.h
@@ -99,21 +99,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the SameEnum2Interface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -121,16 +121,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from SameEnum2Interface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop1 and informs subscriber about the change*/
     void setProp1Local(Enum1Enum prop1);
     /**  Updates local value for Prop2 and informs subscriber about the change*/

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum2interfaceservice.h
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/sameenum2interfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to SameEnum2Interface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of SameEnum2Interface object.
     * @return the set of properties with their current values for the SameEnum2Interface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig1 through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "tb_same2/generated/core/tb_same2.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame2;
@@ -19,17 +20,12 @@ SameStruct1InterfaceClient::SameStruct1InterfaceClient()
     : m_publisher(std::make_unique<SameStruct1InterfacePublisher>())
 {}
 
-void SameStruct1InterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("prop1")) {
-        setProp1Local(fields["prop1"].get<Struct1>());
-    }
-}
-
-void SameStruct1InterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void SameStruct1InterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "prop1") {
-        setProp1Local(value.get<Struct1>());
+        Struct1 value_prop1 {};
+        readValue(value, value_prop1);
+        setProp1Local(value_prop1);
     }
 }
 
@@ -40,7 +36,7 @@ void SameStruct1InterfaceClient::setProp1(const Struct1& prop1)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    m_node->setRemoteProperty(propertyId, prop1);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
 }
 
 void SameStruct1InterfaceClient::setProp1Local(const Struct1& prop1)
@@ -77,10 +73,12 @@ std::future<Struct1> SameStruct1InterfaceClient::func1Async(const Struct1& param
         {
             std::promise<Struct1> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Struct1& value = arg.value.get<Struct1>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Struct1 result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -92,23 +90,31 @@ std::string SameStruct1InterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void SameStruct1InterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void SameStruct1InterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sig1") {
-        m_publisher->publishSig1(args[0].get<Struct1>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sig1") {Struct1 arg_param1 {};
+        argumentsReader.read(arg_param1);m_publisher->publishSig1(arg_param1);   
         return;
     }
 }
 
-void SameStruct1InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void SameStruct1InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void SameStruct1InterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void SameStruct1InterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void SameStruct1InterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceclient.h
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceclient.h
@@ -80,21 +80,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the SameStruct1Interface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -102,16 +102,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from SameStruct1Interface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop1 and informs subscriber about the change*/
     void setProp1Local(const Struct1& prop1);
 

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceservice.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceservice.cpp
@@ -6,6 +6,7 @@
 
 #include "olink/iremotenode.h"
 #include "olink/remoteregistry.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 #include <iostream>
@@ -35,23 +36,25 @@ std::string SameStruct1InterfaceService::olinkObjectName() {
     return interfaceId;
 }
 
-nlohmann::json SameStruct1InterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+ApiGear::ObjectLink::OLinkContent SameStruct1InterfaceService::olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& fcnArgs) {
     AG_LOG_DEBUG("SameStruct1InterfaceService invoke " + methodId);
     const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(fcnArgs);
     if(memberMethod == "func1") {
-        const Struct1& param1 = fcnArgs.at(0);
-        Struct1 result = m_SameStruct1Interface->func1(param1);
-        return result;
+        Struct1 param1{};
+        argumentsReader.read(param1);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SameStruct1Interface->func1(param1));
     }
-    return nlohmann::json();
+    return {};
 }
 
-void SameStruct1InterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+void SameStruct1InterfaceService::olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) {
     AG_LOG_DEBUG("SameStruct1InterfaceService set property " + propertyId);
     const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
     if(memberProperty == "prop1") {
-        Struct1 prop1 = value.get<Struct1>();
-        m_SameStruct1Interface->setProp1(prop1);
+        Struct1 value_prop1{};
+        ApiGear::ObjectLink::readValue(value, value_prop1);
+        m_SameStruct1Interface->setProp1(value_prop1);
     } 
 }
 
@@ -63,15 +66,14 @@ void SameStruct1InterfaceService::olinkUnlinked(const std::string& objectId){
     AG_LOG_DEBUG("SameStruct1InterfaceService unlinked " + objectId);
 }
 
-nlohmann::json SameStruct1InterfaceService::olinkCollectProperties()
+ApiGear::ObjectLink::OLinkContent SameStruct1InterfaceService::olinkCollectProperties()
 {
-    return nlohmann::json::object({
-        { "prop1", m_SameStruct1Interface->getProp1() }
-    });
+    return ApiGear::ObjectLink::argumentsToContent(
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop1"), m_SameStruct1Interface->getProp1()) );
 }
 void SameStruct1InterfaceService::onSig1(const Struct1& param1)
 {
-    const nlohmann::json args = { param1 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -88,7 +90,7 @@ void SameStruct1InterfaceService::onProp1Changed(const Struct1& prop1)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop1);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
         }
     }
 }

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceservice.h
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct1interfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to SameStruct1Interface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of SameStruct1Interface object.
     * @return the set of properties with their current values for the SameStruct1Interface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig1 through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct2interfaceclient.cpp
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct2interfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "tb_same2/generated/core/tb_same2.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSame2;
@@ -19,23 +20,17 @@ SameStruct2InterfaceClient::SameStruct2InterfaceClient()
     : m_publisher(std::make_unique<SameStruct2InterfacePublisher>())
 {}
 
-void SameStruct2InterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("prop1")) {
-        setProp1Local(fields["prop1"].get<Struct2>());
-    }
-    if(fields.contains("prop2")) {
-        setProp2Local(fields["prop2"].get<Struct2>());
-    }
-}
-
-void SameStruct2InterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void SameStruct2InterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "prop1") {
-        setProp1Local(value.get<Struct2>());
+        Struct2 value_prop1 {};
+        readValue(value, value_prop1);
+        setProp1Local(value_prop1);
     }
     else if ( propertyName == "prop2") {
-        setProp2Local(value.get<Struct2>());
+        Struct2 value_prop2 {};
+        readValue(value, value_prop2);
+        setProp2Local(value_prop2);
     }
 }
 
@@ -46,7 +41,7 @@ void SameStruct2InterfaceClient::setProp1(const Struct2& prop1)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    m_node->setRemoteProperty(propertyId, prop1);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
 }
 
 void SameStruct2InterfaceClient::setProp1Local(const Struct2& prop1)
@@ -69,7 +64,7 @@ void SameStruct2InterfaceClient::setProp2(const Struct2& prop2)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    m_node->setRemoteProperty(propertyId, prop2);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop2));
 }
 
 void SameStruct2InterfaceClient::setProp2Local(const Struct2& prop2)
@@ -106,10 +101,12 @@ std::future<Struct1> SameStruct2InterfaceClient::func1Async(const Struct1& param
         {
             std::promise<Struct1> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Struct1& value = arg.value.get<Struct1>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Struct1 result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -138,10 +135,12 @@ std::future<Struct1> SameStruct2InterfaceClient::func2Async(const Struct1& param
         {
             std::promise<Struct1> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const Struct1& value = arg.value.get<Struct1>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1, param2 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    Struct1 result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -153,27 +152,36 @@ std::string SameStruct2InterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void SameStruct2InterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void SameStruct2InterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sig1") {
-        m_publisher->publishSig1(args[0].get<Struct1>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sig1") {Struct1 arg_param1 {};
+        argumentsReader.read(arg_param1);m_publisher->publishSig1(arg_param1);   
         return;
     }
-    if(signalName == "sig2") {
-        m_publisher->publishSig2(args[0].get<Struct1>(),args[1].get<Struct2>());   
+    if(signalName == "sig2") {Struct1 arg_param1 {};
+        argumentsReader.read(arg_param1);Struct2 arg_param2 {};
+        argumentsReader.read(arg_param2);m_publisher->publishSig2(arg_param1,arg_param2);   
         return;
     }
 }
 
-void SameStruct2InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void SameStruct2InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void SameStruct2InterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void SameStruct2InterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void SameStruct2InterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct2interfaceclient.h
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct2interfaceclient.h
@@ -99,21 +99,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the SameStruct2Interface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -121,16 +121,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from SameStruct2Interface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop1 and informs subscriber about the change*/
     void setProp1Local(const Struct2& prop1);
     /**  Updates local value for Prop2 and informs subscriber about the change*/

--- a/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct2interfaceservice.h
+++ b/goldenmaster/modules/tb_same2_module/tb_same2/generated/olink/samestruct2interfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to SameStruct2Interface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of SameStruct2Interface object.
     * @return the set of properties with their current values for the SameStruct2Interface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig1 through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nooperationsinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nooperationsinterfaceclient.h
@@ -81,21 +81,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the NoOperationsInterface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -103,16 +103,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from NoOperationsInterface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for PropBool and informs subscriber about the change*/
     void setPropBoolLocal(bool propBool);
     /**  Updates local value for PropInt and informs subscriber about the change*/

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nooperationsinterfaceservice.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nooperationsinterfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to NoOperationsInterface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of NoOperationsInterface object.
     * @return the set of properties with their current values for the NoOperationsInterface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sigVoid through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nopropertiesinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nopropertiesinterfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "tb_simple/generated/core/tb_simple.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSimple;
@@ -19,13 +20,7 @@ NoPropertiesInterfaceClient::NoPropertiesInterfaceClient()
     : m_publisher(std::make_unique<NoPropertiesInterfacePublisher>())
 {}
 
-void NoPropertiesInterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    // no properties to apply state
-    (void) fields;
-}
-
-void NoPropertiesInterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void NoPropertiesInterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {// no properties to apply state
     (void) propertyName;
     (void) value;
@@ -42,7 +37,7 @@ void NoPropertiesInterfaceClient::funcVoid()
             (void) this;
             (void) arg;
         };
-    const nlohmann::json &args = nlohmann::json::array({  });
+    auto args = ApiGear::ObjectLink::argumentsToContent(  );
     static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
     m_node->invokeRemote(operationId, args, func);
 }
@@ -57,8 +52,9 @@ std::future<void> NoPropertiesInterfaceClient::funcVoidAsync()
         {
             std::promise<void> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcVoid");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            auto args = ApiGear::ObjectLink::argumentsToContent(  );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     (void) arg;
                     resultPromise.set_value();
                 });
@@ -88,10 +84,12 @@ std::future<bool> NoPropertiesInterfaceClient::funcBoolAsync(bool paramBool)
         {
             std::promise<bool> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramBool}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const bool& value = arg.value.get<bool>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramBool );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    bool result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -103,27 +101,34 @@ std::string NoPropertiesInterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void NoPropertiesInterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void NoPropertiesInterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sigVoid") {
-        m_publisher->publishSigVoid();   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sigVoid") {m_publisher->publishSigVoid();   
         return;
     }
-    if(signalName == "sigBool") {
-        m_publisher->publishSigBool(args[0].get<bool>());   
+    if(signalName == "sigBool") {bool arg_paramBool {};
+        argumentsReader.read(arg_paramBool);m_publisher->publishSigBool(arg_paramBool);   
         return;
     }
 }
 
-void NoPropertiesInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void NoPropertiesInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void NoPropertiesInterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void NoPropertiesInterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void NoPropertiesInterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nopropertiesinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nopropertiesinterfaceclient.h
@@ -79,21 +79,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the NoPropertiesInterface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -101,16 +101,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from NoPropertiesInterface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
 
     /** 
     * An abstraction layer over the connection with service for the NoPropertiesInterfaceClient.

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nopropertiesinterfaceservice.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nopropertiesinterfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to NoPropertiesInterface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of NoPropertiesInterface object.
     * @return the set of properties with their current values for the NoPropertiesInterface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sigVoid through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nosignalsinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nosignalsinterfaceclient.h
@@ -99,21 +99,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the NoSignalsInterface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -121,16 +121,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from NoSignalsInterface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for PropBool and informs subscriber about the change*/
     void setPropBoolLocal(bool propBool);
     /**  Updates local value for PropInt and informs subscriber about the change*/

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nosignalsinterfaceservice.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/nosignalsinterfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to NoSignalsInterface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of NoSignalsInterface object.
     * @return the set of properties with their current values for the NoSignalsInterface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards propBool change through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "tb_simple/generated/core/tb_simple.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSimple;
@@ -19,59 +20,47 @@ SimpleArrayInterfaceClient::SimpleArrayInterfaceClient()
     : m_publisher(std::make_unique<SimpleArrayInterfacePublisher>())
 {}
 
-void SimpleArrayInterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("propBool")) {
-        setPropBoolLocal(fields["propBool"].get<std::list<bool>>());
-    }
-    if(fields.contains("propInt")) {
-        setPropIntLocal(fields["propInt"].get<std::list<int>>());
-    }
-    if(fields.contains("propInt32")) {
-        setPropInt32Local(fields["propInt32"].get<std::list<int32_t>>());
-    }
-    if(fields.contains("propInt64")) {
-        setPropInt64Local(fields["propInt64"].get<std::list<int64_t>>());
-    }
-    if(fields.contains("propFloat")) {
-        setPropFloatLocal(fields["propFloat"].get<std::list<float>>());
-    }
-    if(fields.contains("propFloat32")) {
-        setPropFloat32Local(fields["propFloat32"].get<std::list<float>>());
-    }
-    if(fields.contains("propFloat64")) {
-        setPropFloat64Local(fields["propFloat64"].get<std::list<double>>());
-    }
-    if(fields.contains("propString")) {
-        setPropStringLocal(fields["propString"].get<std::list<std::string>>());
-    }
-}
-
-void SimpleArrayInterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void SimpleArrayInterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "propBool") {
-        setPropBoolLocal(value.get<std::list<bool>>());
+        std::list<bool> value_propBool {};
+        readValue(value, value_propBool);
+        setPropBoolLocal(value_propBool);
     }
     else if ( propertyName == "propInt") {
-        setPropIntLocal(value.get<std::list<int>>());
+        std::list<int> value_propInt {};
+        readValue(value, value_propInt);
+        setPropIntLocal(value_propInt);
     }
     else if ( propertyName == "propInt32") {
-        setPropInt32Local(value.get<std::list<int32_t>>());
+        std::list<int32_t> value_propInt32 {};
+        readValue(value, value_propInt32);
+        setPropInt32Local(value_propInt32);
     }
     else if ( propertyName == "propInt64") {
-        setPropInt64Local(value.get<std::list<int64_t>>());
+        std::list<int64_t> value_propInt64 {};
+        readValue(value, value_propInt64);
+        setPropInt64Local(value_propInt64);
     }
     else if ( propertyName == "propFloat") {
-        setPropFloatLocal(value.get<std::list<float>>());
+        std::list<float> value_propFloat {};
+        readValue(value, value_propFloat);
+        setPropFloatLocal(value_propFloat);
     }
     else if ( propertyName == "propFloat32") {
-        setPropFloat32Local(value.get<std::list<float>>());
+        std::list<float> value_propFloat32 {};
+        readValue(value, value_propFloat32);
+        setPropFloat32Local(value_propFloat32);
     }
     else if ( propertyName == "propFloat64") {
-        setPropFloat64Local(value.get<std::list<double>>());
+        std::list<double> value_propFloat64 {};
+        readValue(value, value_propFloat64);
+        setPropFloat64Local(value_propFloat64);
     }
     else if ( propertyName == "propString") {
-        setPropStringLocal(value.get<std::list<std::string>>());
+        std::list<std::string> value_propString {};
+        readValue(value, value_propString);
+        setPropStringLocal(value_propString);
     }
 }
 
@@ -82,7 +71,7 @@ void SimpleArrayInterfaceClient::setPropBool(const std::list<bool>& propBool)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
-    m_node->setRemoteProperty(propertyId, propBool);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propBool));
 }
 
 void SimpleArrayInterfaceClient::setPropBoolLocal(const std::list<bool>& propBool)
@@ -105,7 +94,7 @@ void SimpleArrayInterfaceClient::setPropInt(const std::list<int>& propInt)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
-    m_node->setRemoteProperty(propertyId, propInt);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propInt));
 }
 
 void SimpleArrayInterfaceClient::setPropIntLocal(const std::list<int>& propInt)
@@ -128,7 +117,7 @@ void SimpleArrayInterfaceClient::setPropInt32(const std::list<int32_t>& propInt3
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt32");
-    m_node->setRemoteProperty(propertyId, propInt32);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propInt32));
 }
 
 void SimpleArrayInterfaceClient::setPropInt32Local(const std::list<int32_t>& propInt32)
@@ -151,7 +140,7 @@ void SimpleArrayInterfaceClient::setPropInt64(const std::list<int64_t>& propInt6
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt64");
-    m_node->setRemoteProperty(propertyId, propInt64);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propInt64));
 }
 
 void SimpleArrayInterfaceClient::setPropInt64Local(const std::list<int64_t>& propInt64)
@@ -174,7 +163,7 @@ void SimpleArrayInterfaceClient::setPropFloat(const std::list<float>& propFloat)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
-    m_node->setRemoteProperty(propertyId, propFloat);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat));
 }
 
 void SimpleArrayInterfaceClient::setPropFloatLocal(const std::list<float>& propFloat)
@@ -197,7 +186,7 @@ void SimpleArrayInterfaceClient::setPropFloat32(const std::list<float>& propFloa
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat32");
-    m_node->setRemoteProperty(propertyId, propFloat32);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat32));
 }
 
 void SimpleArrayInterfaceClient::setPropFloat32Local(const std::list<float>& propFloat32)
@@ -220,7 +209,7 @@ void SimpleArrayInterfaceClient::setPropFloat64(const std::list<double>& propFlo
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat64");
-    m_node->setRemoteProperty(propertyId, propFloat64);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat64));
 }
 
 void SimpleArrayInterfaceClient::setPropFloat64Local(const std::list<double>& propFloat64)
@@ -243,7 +232,7 @@ void SimpleArrayInterfaceClient::setPropString(const std::list<std::string>& pro
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
-    m_node->setRemoteProperty(propertyId, propString);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propString));
 }
 
 void SimpleArrayInterfaceClient::setPropStringLocal(const std::list<std::string>& propString)
@@ -280,10 +269,12 @@ std::future<std::list<bool>> SimpleArrayInterfaceClient::funcBoolAsync(const std
         {
             std::promise<std::list<bool>> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramBool}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const std::list<bool>& value = arg.value.get<std::list<bool>>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramBool );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    std::list<bool> result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -311,10 +302,12 @@ std::future<std::list<int>> SimpleArrayInterfaceClient::funcIntAsync(const std::
         {
             std::promise<std::list<int>> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramInt}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const std::list<int>& value = arg.value.get<std::list<int>>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramInt );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    std::list<int> result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -342,10 +335,12 @@ std::future<std::list<int32_t>> SimpleArrayInterfaceClient::funcInt32Async(const
         {
             std::promise<std::list<int32_t>> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt32");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramInt32}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const std::list<int32_t>& value = arg.value.get<std::list<int32_t>>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramInt32 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    std::list<int32_t> result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -373,10 +368,12 @@ std::future<std::list<int64_t>> SimpleArrayInterfaceClient::funcInt64Async(const
         {
             std::promise<std::list<int64_t>> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt64");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramInt64}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const std::list<int64_t>& value = arg.value.get<std::list<int64_t>>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramInt64 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    std::list<int64_t> result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -404,10 +401,12 @@ std::future<std::list<float>> SimpleArrayInterfaceClient::funcFloatAsync(const s
         {
             std::promise<std::list<float>> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const std::list<float>& value = arg.value.get<std::list<float>>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramFloat );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    std::list<float> result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -435,10 +434,12 @@ std::future<std::list<float>> SimpleArrayInterfaceClient::funcFloat32Async(const
         {
             std::promise<std::list<float>> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat32");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramFloat32}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const std::list<float>& value = arg.value.get<std::list<float>>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramFloat32 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    std::list<float> result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -466,10 +467,12 @@ std::future<std::list<double>> SimpleArrayInterfaceClient::funcFloat64Async(cons
         {
             std::promise<std::list<double>> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat64");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const std::list<double>& value = arg.value.get<std::list<double>>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramFloat );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    std::list<double> result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -497,10 +500,12 @@ std::future<std::list<std::string>> SimpleArrayInterfaceClient::funcStringAsync(
         {
             std::promise<std::list<std::string>> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramString}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const std::list<std::string>& value = arg.value.get<std::list<std::string>>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramString );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    std::list<std::string> result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -512,51 +517,59 @@ std::string SimpleArrayInterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void SimpleArrayInterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void SimpleArrayInterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sigBool") {
-        m_publisher->publishSigBool(args[0].get<std::list<bool>>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sigBool") {std::list<bool> arg_paramBool {};
+        argumentsReader.read(arg_paramBool);m_publisher->publishSigBool(arg_paramBool);   
         return;
     }
-    if(signalName == "sigInt") {
-        m_publisher->publishSigInt(args[0].get<std::list<int>>());   
+    if(signalName == "sigInt") {std::list<int> arg_paramInt {};
+        argumentsReader.read(arg_paramInt);m_publisher->publishSigInt(arg_paramInt);   
         return;
     }
-    if(signalName == "sigInt32") {
-        m_publisher->publishSigInt32(args[0].get<std::list<int32_t>>());   
+    if(signalName == "sigInt32") {std::list<int32_t> arg_paramInt32 {};
+        argumentsReader.read(arg_paramInt32);m_publisher->publishSigInt32(arg_paramInt32);   
         return;
     }
-    if(signalName == "sigInt64") {
-        m_publisher->publishSigInt64(args[0].get<std::list<int64_t>>());   
+    if(signalName == "sigInt64") {std::list<int64_t> arg_paramInt64 {};
+        argumentsReader.read(arg_paramInt64);m_publisher->publishSigInt64(arg_paramInt64);   
         return;
     }
-    if(signalName == "sigFloat") {
-        m_publisher->publishSigFloat(args[0].get<std::list<float>>());   
+    if(signalName == "sigFloat") {std::list<float> arg_paramFloat {};
+        argumentsReader.read(arg_paramFloat);m_publisher->publishSigFloat(arg_paramFloat);   
         return;
     }
-    if(signalName == "sigFloat32") {
-        m_publisher->publishSigFloat32(args[0].get<std::list<float>>());   
+    if(signalName == "sigFloat32") {std::list<float> arg_paramFloa32 {};
+        argumentsReader.read(arg_paramFloa32);m_publisher->publishSigFloat32(arg_paramFloa32);   
         return;
     }
-    if(signalName == "sigFloat64") {
-        m_publisher->publishSigFloat64(args[0].get<std::list<double>>());   
+    if(signalName == "sigFloat64") {std::list<double> arg_paramFloat64 {};
+        argumentsReader.read(arg_paramFloat64);m_publisher->publishSigFloat64(arg_paramFloat64);   
         return;
     }
-    if(signalName == "sigString") {
-        m_publisher->publishSigString(args[0].get<std::list<std::string>>());   
+    if(signalName == "sigString") {std::list<std::string> arg_paramString {};
+        argumentsReader.read(arg_paramString);m_publisher->publishSigString(arg_paramString);   
         return;
     }
 }
 
-void SimpleArrayInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void SimpleArrayInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void SimpleArrayInterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void SimpleArrayInterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void SimpleArrayInterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceclient.h
@@ -213,21 +213,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the SimpleArrayInterface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -235,16 +235,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from SimpleArrayInterface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for PropBool and informs subscriber about the change*/
     void setPropBoolLocal(const std::list<bool>& propBool);
     /**  Updates local value for PropInt and informs subscriber about the change*/

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceservice.cpp
@@ -6,6 +6,7 @@
 
 #include "olink/iremotenode.h"
 #include "olink/remoteregistry.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 #include <iostream>
@@ -35,86 +36,95 @@ std::string SimpleArrayInterfaceService::olinkObjectName() {
     return interfaceId;
 }
 
-nlohmann::json SimpleArrayInterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+ApiGear::ObjectLink::OLinkContent SimpleArrayInterfaceService::olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& fcnArgs) {
     AG_LOG_DEBUG("SimpleArrayInterfaceService invoke " + methodId);
     const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(fcnArgs);
     if(memberMethod == "funcBool") {
-        const std::list<bool>& paramBool = fcnArgs.at(0);
-        std::list<bool> result = m_SimpleArrayInterface->funcBool(paramBool);
-        return result;
+        std::list<bool> paramBool{};
+        argumentsReader.read(paramBool);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleArrayInterface->funcBool(paramBool));
     }
     if(memberMethod == "funcInt") {
-        const std::list<int>& paramInt = fcnArgs.at(0);
-        std::list<int> result = m_SimpleArrayInterface->funcInt(paramInt);
-        return result;
+        std::list<int> paramInt{};
+        argumentsReader.read(paramInt);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleArrayInterface->funcInt(paramInt));
     }
     if(memberMethod == "funcInt32") {
-        const std::list<int32_t>& paramInt32 = fcnArgs.at(0);
-        std::list<int32_t> result = m_SimpleArrayInterface->funcInt32(paramInt32);
-        return result;
+        std::list<int32_t> paramInt32{};
+        argumentsReader.read(paramInt32);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleArrayInterface->funcInt32(paramInt32));
     }
     if(memberMethod == "funcInt64") {
-        const std::list<int64_t>& paramInt64 = fcnArgs.at(0);
-        std::list<int64_t> result = m_SimpleArrayInterface->funcInt64(paramInt64);
-        return result;
+        std::list<int64_t> paramInt64{};
+        argumentsReader.read(paramInt64);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleArrayInterface->funcInt64(paramInt64));
     }
     if(memberMethod == "funcFloat") {
-        const std::list<float>& paramFloat = fcnArgs.at(0);
-        std::list<float> result = m_SimpleArrayInterface->funcFloat(paramFloat);
-        return result;
+        std::list<float> paramFloat{};
+        argumentsReader.read(paramFloat);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleArrayInterface->funcFloat(paramFloat));
     }
     if(memberMethod == "funcFloat32") {
-        const std::list<float>& paramFloat32 = fcnArgs.at(0);
-        std::list<float> result = m_SimpleArrayInterface->funcFloat32(paramFloat32);
-        return result;
+        std::list<float> paramFloat32{};
+        argumentsReader.read(paramFloat32);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleArrayInterface->funcFloat32(paramFloat32));
     }
     if(memberMethod == "funcFloat64") {
-        const std::list<double>& paramFloat = fcnArgs.at(0);
-        std::list<double> result = m_SimpleArrayInterface->funcFloat64(paramFloat);
-        return result;
+        std::list<double> paramFloat{};
+        argumentsReader.read(paramFloat);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleArrayInterface->funcFloat64(paramFloat));
     }
     if(memberMethod == "funcString") {
-        const std::list<std::string>& paramString = fcnArgs.at(0);
-        std::list<std::string> result = m_SimpleArrayInterface->funcString(paramString);
-        return result;
+        std::list<std::string> paramString{};
+        argumentsReader.read(paramString);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleArrayInterface->funcString(paramString));
     }
-    return nlohmann::json();
+    return {};
 }
 
-void SimpleArrayInterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+void SimpleArrayInterfaceService::olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) {
     AG_LOG_DEBUG("SimpleArrayInterfaceService set property " + propertyId);
     const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
     if(memberProperty == "propBool") {
-        std::list<bool> propBool = value.get<std::list<bool>>();
-        m_SimpleArrayInterface->setPropBool(propBool);
+        std::list<bool> value_propBool{};
+        ApiGear::ObjectLink::readValue(value, value_propBool);
+        m_SimpleArrayInterface->setPropBool(value_propBool);
     }
     if(memberProperty == "propInt") {
-        std::list<int> propInt = value.get<std::list<int>>();
-        m_SimpleArrayInterface->setPropInt(propInt);
+        std::list<int> value_propInt{};
+        ApiGear::ObjectLink::readValue(value, value_propInt);
+        m_SimpleArrayInterface->setPropInt(value_propInt);
     }
     if(memberProperty == "propInt32") {
-        std::list<int32_t> propInt32 = value.get<std::list<int32_t>>();
-        m_SimpleArrayInterface->setPropInt32(propInt32);
+        std::list<int32_t> value_propInt32{};
+        ApiGear::ObjectLink::readValue(value, value_propInt32);
+        m_SimpleArrayInterface->setPropInt32(value_propInt32);
     }
     if(memberProperty == "propInt64") {
-        std::list<int64_t> propInt64 = value.get<std::list<int64_t>>();
-        m_SimpleArrayInterface->setPropInt64(propInt64);
+        std::list<int64_t> value_propInt64{};
+        ApiGear::ObjectLink::readValue(value, value_propInt64);
+        m_SimpleArrayInterface->setPropInt64(value_propInt64);
     }
     if(memberProperty == "propFloat") {
-        std::list<float> propFloat = value.get<std::list<float>>();
-        m_SimpleArrayInterface->setPropFloat(propFloat);
+        std::list<float> value_propFloat{};
+        ApiGear::ObjectLink::readValue(value, value_propFloat);
+        m_SimpleArrayInterface->setPropFloat(value_propFloat);
     }
     if(memberProperty == "propFloat32") {
-        std::list<float> propFloat32 = value.get<std::list<float>>();
-        m_SimpleArrayInterface->setPropFloat32(propFloat32);
+        std::list<float> value_propFloat32{};
+        ApiGear::ObjectLink::readValue(value, value_propFloat32);
+        m_SimpleArrayInterface->setPropFloat32(value_propFloat32);
     }
     if(memberProperty == "propFloat64") {
-        std::list<double> propFloat64 = value.get<std::list<double>>();
-        m_SimpleArrayInterface->setPropFloat64(propFloat64);
+        std::list<double> value_propFloat64{};
+        ApiGear::ObjectLink::readValue(value, value_propFloat64);
+        m_SimpleArrayInterface->setPropFloat64(value_propFloat64);
     }
     if(memberProperty == "propString") {
-        std::list<std::string> propString = value.get<std::list<std::string>>();
-        m_SimpleArrayInterface->setPropString(propString);
+        std::list<std::string> value_propString{};
+        ApiGear::ObjectLink::readValue(value, value_propString);
+        m_SimpleArrayInterface->setPropString(value_propString);
     } 
 }
 
@@ -126,22 +136,21 @@ void SimpleArrayInterfaceService::olinkUnlinked(const std::string& objectId){
     AG_LOG_DEBUG("SimpleArrayInterfaceService unlinked " + objectId);
 }
 
-nlohmann::json SimpleArrayInterfaceService::olinkCollectProperties()
+ApiGear::ObjectLink::OLinkContent SimpleArrayInterfaceService::olinkCollectProperties()
 {
-    return nlohmann::json::object({
-        { "propBool", m_SimpleArrayInterface->getPropBool() },
-        { "propInt", m_SimpleArrayInterface->getPropInt() },
-        { "propInt32", m_SimpleArrayInterface->getPropInt32() },
-        { "propInt64", m_SimpleArrayInterface->getPropInt64() },
-        { "propFloat", m_SimpleArrayInterface->getPropFloat() },
-        { "propFloat32", m_SimpleArrayInterface->getPropFloat32() },
-        { "propFloat64", m_SimpleArrayInterface->getPropFloat64() },
-        { "propString", m_SimpleArrayInterface->getPropString() }
-    });
+    return ApiGear::ObjectLink::argumentsToContent(
+        ApiGear::ObjectLink::toInitialProperty(std::string("propBool"), m_SimpleArrayInterface->getPropBool()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propInt"), m_SimpleArrayInterface->getPropInt()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propInt32"), m_SimpleArrayInterface->getPropInt32()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propInt64"), m_SimpleArrayInterface->getPropInt64()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propFloat"), m_SimpleArrayInterface->getPropFloat()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propFloat32"), m_SimpleArrayInterface->getPropFloat32()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propFloat64"), m_SimpleArrayInterface->getPropFloat64()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propString"), m_SimpleArrayInterface->getPropString()) );
 }
 void SimpleArrayInterfaceService::onSigBool(const std::list<bool>& paramBool)
 {
-    const nlohmann::json args = { paramBool };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramBool);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -153,7 +162,7 @@ void SimpleArrayInterfaceService::onSigBool(const std::list<bool>& paramBool)
 }
 void SimpleArrayInterfaceService::onSigInt(const std::list<int>& paramInt)
 {
-    const nlohmann::json args = { paramInt };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramInt);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -165,7 +174,7 @@ void SimpleArrayInterfaceService::onSigInt(const std::list<int>& paramInt)
 }
 void SimpleArrayInterfaceService::onSigInt32(const std::list<int32_t>& paramInt32)
 {
-    const nlohmann::json args = { paramInt32 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramInt32);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt32");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -177,7 +186,7 @@ void SimpleArrayInterfaceService::onSigInt32(const std::list<int32_t>& paramInt3
 }
 void SimpleArrayInterfaceService::onSigInt64(const std::list<int64_t>& paramInt64)
 {
-    const nlohmann::json args = { paramInt64 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramInt64);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt64");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -189,7 +198,7 @@ void SimpleArrayInterfaceService::onSigInt64(const std::list<int64_t>& paramInt6
 }
 void SimpleArrayInterfaceService::onSigFloat(const std::list<float>& paramFloat)
 {
-    const nlohmann::json args = { paramFloat };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramFloat);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -201,7 +210,7 @@ void SimpleArrayInterfaceService::onSigFloat(const std::list<float>& paramFloat)
 }
 void SimpleArrayInterfaceService::onSigFloat32(const std::list<float>& paramFloa32)
 {
-    const nlohmann::json args = { paramFloa32 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramFloa32);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat32");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -213,7 +222,7 @@ void SimpleArrayInterfaceService::onSigFloat32(const std::list<float>& paramFloa
 }
 void SimpleArrayInterfaceService::onSigFloat64(const std::list<double>& paramFloat64)
 {
-    const nlohmann::json args = { paramFloat64 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramFloat64);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat64");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -225,7 +234,7 @@ void SimpleArrayInterfaceService::onSigFloat64(const std::list<double>& paramFlo
 }
 void SimpleArrayInterfaceService::onSigString(const std::list<std::string>& paramString)
 {
-    const nlohmann::json args = { paramString };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramString);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -242,7 +251,7 @@ void SimpleArrayInterfaceService::onPropBoolChanged(const std::list<bool>& propB
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propBool);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propBool));
         }
     }
 }
@@ -253,7 +262,7 @@ void SimpleArrayInterfaceService::onPropIntChanged(const std::list<int>& propInt
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propInt);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propInt));
         }
     }
 }
@@ -264,7 +273,7 @@ void SimpleArrayInterfaceService::onPropInt32Changed(const std::list<int32_t>& p
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propInt32);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propInt32));
         }
     }
 }
@@ -275,7 +284,7 @@ void SimpleArrayInterfaceService::onPropInt64Changed(const std::list<int64_t>& p
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propInt64);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propInt64));
         }
     }
 }
@@ -286,7 +295,7 @@ void SimpleArrayInterfaceService::onPropFloatChanged(const std::list<float>& pro
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propFloat);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat));
         }
     }
 }
@@ -297,7 +306,7 @@ void SimpleArrayInterfaceService::onPropFloat32Changed(const std::list<float>& p
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propFloat32);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat32));
         }
     }
 }
@@ -308,7 +317,7 @@ void SimpleArrayInterfaceService::onPropFloat64Changed(const std::list<double>& 
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propFloat64);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat64));
         }
     }
 }
@@ -319,7 +328,7 @@ void SimpleArrayInterfaceService::onPropStringChanged(const std::list<std::strin
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propString);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propString));
         }
     }
 }

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceservice.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simplearrayinterfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to SimpleArrayInterface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of SimpleArrayInterface object.
     * @return the set of properties with their current values for the SimpleArrayInterface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sigBool through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "tb_simple/generated/core/tb_simple.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::TbSimple;
@@ -19,59 +20,47 @@ SimpleInterfaceClient::SimpleInterfaceClient()
     : m_publisher(std::make_unique<SimpleInterfacePublisher>())
 {}
 
-void SimpleInterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("propBool")) {
-        setPropBoolLocal(fields["propBool"].get<bool>());
-    }
-    if(fields.contains("propInt")) {
-        setPropIntLocal(fields["propInt"].get<int>());
-    }
-    if(fields.contains("propInt32")) {
-        setPropInt32Local(fields["propInt32"].get<int32_t>());
-    }
-    if(fields.contains("propInt64")) {
-        setPropInt64Local(fields["propInt64"].get<int64_t>());
-    }
-    if(fields.contains("propFloat")) {
-        setPropFloatLocal(fields["propFloat"].get<float>());
-    }
-    if(fields.contains("propFloat32")) {
-        setPropFloat32Local(fields["propFloat32"].get<float>());
-    }
-    if(fields.contains("propFloat64")) {
-        setPropFloat64Local(fields["propFloat64"].get<double>());
-    }
-    if(fields.contains("propString")) {
-        setPropStringLocal(fields["propString"].get<std::string>());
-    }
-}
-
-void SimpleInterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void SimpleInterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "propBool") {
-        setPropBoolLocal(value.get<bool>());
+        bool value_propBool {};
+        readValue(value, value_propBool);
+        setPropBoolLocal(value_propBool);
     }
     else if ( propertyName == "propInt") {
-        setPropIntLocal(value.get<int>());
+        int value_propInt {};
+        readValue(value, value_propInt);
+        setPropIntLocal(value_propInt);
     }
     else if ( propertyName == "propInt32") {
-        setPropInt32Local(value.get<int32_t>());
+        int32_t value_propInt32 {};
+        readValue(value, value_propInt32);
+        setPropInt32Local(value_propInt32);
     }
     else if ( propertyName == "propInt64") {
-        setPropInt64Local(value.get<int64_t>());
+        int64_t value_propInt64 {};
+        readValue(value, value_propInt64);
+        setPropInt64Local(value_propInt64);
     }
     else if ( propertyName == "propFloat") {
-        setPropFloatLocal(value.get<float>());
+        float value_propFloat {};
+        readValue(value, value_propFloat);
+        setPropFloatLocal(value_propFloat);
     }
     else if ( propertyName == "propFloat32") {
-        setPropFloat32Local(value.get<float>());
+        float value_propFloat32 {};
+        readValue(value, value_propFloat32);
+        setPropFloat32Local(value_propFloat32);
     }
     else if ( propertyName == "propFloat64") {
-        setPropFloat64Local(value.get<double>());
+        double value_propFloat64 {};
+        readValue(value, value_propFloat64);
+        setPropFloat64Local(value_propFloat64);
     }
     else if ( propertyName == "propString") {
-        setPropStringLocal(value.get<std::string>());
+        std::string value_propString {};
+        readValue(value, value_propString);
+        setPropStringLocal(value_propString);
     }
 }
 
@@ -82,7 +71,7 @@ void SimpleInterfaceClient::setPropBool(bool propBool)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
-    m_node->setRemoteProperty(propertyId, propBool);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propBool));
 }
 
 void SimpleInterfaceClient::setPropBoolLocal(bool propBool)
@@ -105,7 +94,7 @@ void SimpleInterfaceClient::setPropInt(int propInt)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
-    m_node->setRemoteProperty(propertyId, propInt);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propInt));
 }
 
 void SimpleInterfaceClient::setPropIntLocal(int propInt)
@@ -128,7 +117,7 @@ void SimpleInterfaceClient::setPropInt32(int32_t propInt32)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt32");
-    m_node->setRemoteProperty(propertyId, propInt32);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propInt32));
 }
 
 void SimpleInterfaceClient::setPropInt32Local(int32_t propInt32)
@@ -151,7 +140,7 @@ void SimpleInterfaceClient::setPropInt64(int64_t propInt64)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt64");
-    m_node->setRemoteProperty(propertyId, propInt64);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propInt64));
 }
 
 void SimpleInterfaceClient::setPropInt64Local(int64_t propInt64)
@@ -174,7 +163,7 @@ void SimpleInterfaceClient::setPropFloat(float propFloat)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
-    m_node->setRemoteProperty(propertyId, propFloat);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat));
 }
 
 void SimpleInterfaceClient::setPropFloatLocal(float propFloat)
@@ -197,7 +186,7 @@ void SimpleInterfaceClient::setPropFloat32(float propFloat32)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat32");
-    m_node->setRemoteProperty(propertyId, propFloat32);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat32));
 }
 
 void SimpleInterfaceClient::setPropFloat32Local(float propFloat32)
@@ -220,7 +209,7 @@ void SimpleInterfaceClient::setPropFloat64(double propFloat64)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat64");
-    m_node->setRemoteProperty(propertyId, propFloat64);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat64));
 }
 
 void SimpleInterfaceClient::setPropFloat64Local(double propFloat64)
@@ -243,7 +232,7 @@ void SimpleInterfaceClient::setPropString(const std::string& propString)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
-    m_node->setRemoteProperty(propertyId, propString);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propString));
 }
 
 void SimpleInterfaceClient::setPropStringLocal(const std::string& propString)
@@ -270,7 +259,7 @@ void SimpleInterfaceClient::funcNoReturnValue(bool paramBool)
             (void) this;
             (void) arg;
         };
-    const nlohmann::json &args = nlohmann::json::array({ paramBool });
+    auto args = ApiGear::ObjectLink::argumentsToContent( paramBool );
     static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcNoReturnValue");
     m_node->invokeRemote(operationId, args, func);
 }
@@ -286,8 +275,9 @@ std::future<void> SimpleInterfaceClient::funcNoReturnValueAsync(bool paramBool)
         {
             std::promise<void> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcNoReturnValue");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramBool}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramBool );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
                     (void) arg;
                     resultPromise.set_value();
                 });
@@ -317,10 +307,12 @@ std::future<bool> SimpleInterfaceClient::funcBoolAsync(bool paramBool)
         {
             std::promise<bool> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramBool}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const bool& value = arg.value.get<bool>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramBool );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    bool result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -348,10 +340,12 @@ std::future<int> SimpleInterfaceClient::funcIntAsync(int paramInt)
         {
             std::promise<int> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramInt}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const int& value = arg.value.get<int>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramInt );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    int result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -379,10 +373,12 @@ std::future<int32_t> SimpleInterfaceClient::funcInt32Async(int32_t paramInt32)
         {
             std::promise<int32_t> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt32");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramInt32}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const int32_t& value = arg.value.get<int32_t>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramInt32 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    int32_t result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -410,10 +406,12 @@ std::future<int64_t> SimpleInterfaceClient::funcInt64Async(int64_t paramInt64)
         {
             std::promise<int64_t> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt64");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramInt64}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const int64_t& value = arg.value.get<int64_t>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramInt64 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    int64_t result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -441,10 +439,12 @@ std::future<float> SimpleInterfaceClient::funcFloatAsync(float paramFloat)
         {
             std::promise<float> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const float& value = arg.value.get<float>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramFloat );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    float result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -472,10 +472,12 @@ std::future<float> SimpleInterfaceClient::funcFloat32Async(float paramFloat32)
         {
             std::promise<float> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat32");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramFloat32}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const float& value = arg.value.get<float>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramFloat32 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    float result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -503,10 +505,12 @@ std::future<double> SimpleInterfaceClient::funcFloat64Async(double paramFloat)
         {
             std::promise<double> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat64");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const double& value = arg.value.get<double>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramFloat );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    double result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -534,10 +538,12 @@ std::future<std::string> SimpleInterfaceClient::funcStringAsync(const std::strin
         {
             std::promise<std::string> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramString}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const std::string& value = arg.value.get<std::string>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramString );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    std::string result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -549,51 +555,59 @@ std::string SimpleInterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void SimpleInterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void SimpleInterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sigBool") {
-        m_publisher->publishSigBool(args[0].get<bool>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sigBool") {bool arg_paramBool {};
+        argumentsReader.read(arg_paramBool);m_publisher->publishSigBool(arg_paramBool);   
         return;
     }
-    if(signalName == "sigInt") {
-        m_publisher->publishSigInt(args[0].get<int>());   
+    if(signalName == "sigInt") {int arg_paramInt {};
+        argumentsReader.read(arg_paramInt);m_publisher->publishSigInt(arg_paramInt);   
         return;
     }
-    if(signalName == "sigInt32") {
-        m_publisher->publishSigInt32(args[0].get<int32_t>());   
+    if(signalName == "sigInt32") {int32_t arg_paramInt32 {};
+        argumentsReader.read(arg_paramInt32);m_publisher->publishSigInt32(arg_paramInt32);   
         return;
     }
-    if(signalName == "sigInt64") {
-        m_publisher->publishSigInt64(args[0].get<int64_t>());   
+    if(signalName == "sigInt64") {int64_t arg_paramInt64 {};
+        argumentsReader.read(arg_paramInt64);m_publisher->publishSigInt64(arg_paramInt64);   
         return;
     }
-    if(signalName == "sigFloat") {
-        m_publisher->publishSigFloat(args[0].get<float>());   
+    if(signalName == "sigFloat") {float arg_paramFloat {};
+        argumentsReader.read(arg_paramFloat);m_publisher->publishSigFloat(arg_paramFloat);   
         return;
     }
-    if(signalName == "sigFloat32") {
-        m_publisher->publishSigFloat32(args[0].get<float>());   
+    if(signalName == "sigFloat32") {float arg_paramFloa32 {};
+        argumentsReader.read(arg_paramFloa32);m_publisher->publishSigFloat32(arg_paramFloa32);   
         return;
     }
-    if(signalName == "sigFloat64") {
-        m_publisher->publishSigFloat64(args[0].get<double>());   
+    if(signalName == "sigFloat64") {double arg_paramFloat64 {};
+        argumentsReader.read(arg_paramFloat64);m_publisher->publishSigFloat64(arg_paramFloat64);   
         return;
     }
-    if(signalName == "sigString") {
-        m_publisher->publishSigString(args[0].get<std::string>());   
+    if(signalName == "sigString") {std::string arg_paramString {};
+        argumentsReader.read(arg_paramString);m_publisher->publishSigString(arg_paramString);   
         return;
     }
 }
 
-void SimpleInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void SimpleInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void SimpleInterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void SimpleInterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void SimpleInterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceclient.h
@@ -222,21 +222,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the SimpleInterface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -244,16 +244,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from SimpleInterface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for PropBool and informs subscriber about the change*/
     void setPropBoolLocal(bool propBool);
     /**  Updates local value for PropInt and informs subscriber about the change*/

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceservice.cpp
@@ -6,6 +6,7 @@
 
 #include "olink/iremotenode.h"
 #include "olink/remoteregistry.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 #include <iostream>
@@ -35,91 +36,101 @@ std::string SimpleInterfaceService::olinkObjectName() {
     return interfaceId;
 }
 
-nlohmann::json SimpleInterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+ApiGear::ObjectLink::OLinkContent SimpleInterfaceService::olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& fcnArgs) {
     AG_LOG_DEBUG("SimpleInterfaceService invoke " + methodId);
     const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(fcnArgs);
     if(memberMethod == "funcNoReturnValue") {
-        const bool& paramBool = fcnArgs.at(0);
+        bool paramBool{};
+        argumentsReader.read(paramBool);
         m_SimpleInterface->funcNoReturnValue(paramBool);
-        return nlohmann::json{};
+        return {};
     }
     if(memberMethod == "funcBool") {
-        const bool& paramBool = fcnArgs.at(0);
-        bool result = m_SimpleInterface->funcBool(paramBool);
-        return result;
+        bool paramBool{};
+        argumentsReader.read(paramBool);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleInterface->funcBool(paramBool));
     }
     if(memberMethod == "funcInt") {
-        const int& paramInt = fcnArgs.at(0);
-        int result = m_SimpleInterface->funcInt(paramInt);
-        return result;
+        int paramInt{};
+        argumentsReader.read(paramInt);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleInterface->funcInt(paramInt));
     }
     if(memberMethod == "funcInt32") {
-        const int32_t& paramInt32 = fcnArgs.at(0);
-        int32_t result = m_SimpleInterface->funcInt32(paramInt32);
-        return result;
+        int32_t paramInt32{};
+        argumentsReader.read(paramInt32);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleInterface->funcInt32(paramInt32));
     }
     if(memberMethod == "funcInt64") {
-        const int64_t& paramInt64 = fcnArgs.at(0);
-        int64_t result = m_SimpleInterface->funcInt64(paramInt64);
-        return result;
+        int64_t paramInt64{};
+        argumentsReader.read(paramInt64);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleInterface->funcInt64(paramInt64));
     }
     if(memberMethod == "funcFloat") {
-        const float& paramFloat = fcnArgs.at(0);
-        float result = m_SimpleInterface->funcFloat(paramFloat);
-        return result;
+        float paramFloat{};
+        argumentsReader.read(paramFloat);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleInterface->funcFloat(paramFloat));
     }
     if(memberMethod == "funcFloat32") {
-        const float& paramFloat32 = fcnArgs.at(0);
-        float result = m_SimpleInterface->funcFloat32(paramFloat32);
-        return result;
+        float paramFloat32{};
+        argumentsReader.read(paramFloat32);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleInterface->funcFloat32(paramFloat32));
     }
     if(memberMethod == "funcFloat64") {
-        const double& paramFloat = fcnArgs.at(0);
-        double result = m_SimpleInterface->funcFloat64(paramFloat);
-        return result;
+        double paramFloat{};
+        argumentsReader.read(paramFloat);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleInterface->funcFloat64(paramFloat));
     }
     if(memberMethod == "funcString") {
-        const std::string& paramString = fcnArgs.at(0);
-        std::string result = m_SimpleInterface->funcString(paramString);
-        return result;
+        std::string paramString{};
+        argumentsReader.read(paramString);
+        return ApiGear::ObjectLink::invokeReturnValue(m_SimpleInterface->funcString(paramString));
     }
-    return nlohmann::json();
+    return {};
 }
 
-void SimpleInterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+void SimpleInterfaceService::olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) {
     AG_LOG_DEBUG("SimpleInterfaceService set property " + propertyId);
     const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
     if(memberProperty == "propBool") {
-        bool propBool = value.get<bool>();
-        m_SimpleInterface->setPropBool(propBool);
+        bool value_propBool{};
+        ApiGear::ObjectLink::readValue(value, value_propBool);
+        m_SimpleInterface->setPropBool(value_propBool);
     }
     if(memberProperty == "propInt") {
-        int propInt = value.get<int>();
-        m_SimpleInterface->setPropInt(propInt);
+        int value_propInt{};
+        ApiGear::ObjectLink::readValue(value, value_propInt);
+        m_SimpleInterface->setPropInt(value_propInt);
     }
     if(memberProperty == "propInt32") {
-        int32_t propInt32 = value.get<int32_t>();
-        m_SimpleInterface->setPropInt32(propInt32);
+        int32_t value_propInt32{};
+        ApiGear::ObjectLink::readValue(value, value_propInt32);
+        m_SimpleInterface->setPropInt32(value_propInt32);
     }
     if(memberProperty == "propInt64") {
-        int64_t propInt64 = value.get<int64_t>();
-        m_SimpleInterface->setPropInt64(propInt64);
+        int64_t value_propInt64{};
+        ApiGear::ObjectLink::readValue(value, value_propInt64);
+        m_SimpleInterface->setPropInt64(value_propInt64);
     }
     if(memberProperty == "propFloat") {
-        float propFloat = value.get<float>();
-        m_SimpleInterface->setPropFloat(propFloat);
+        float value_propFloat{};
+        ApiGear::ObjectLink::readValue(value, value_propFloat);
+        m_SimpleInterface->setPropFloat(value_propFloat);
     }
     if(memberProperty == "propFloat32") {
-        float propFloat32 = value.get<float>();
-        m_SimpleInterface->setPropFloat32(propFloat32);
+        float value_propFloat32{};
+        ApiGear::ObjectLink::readValue(value, value_propFloat32);
+        m_SimpleInterface->setPropFloat32(value_propFloat32);
     }
     if(memberProperty == "propFloat64") {
-        double propFloat64 = value.get<double>();
-        m_SimpleInterface->setPropFloat64(propFloat64);
+        double value_propFloat64{};
+        ApiGear::ObjectLink::readValue(value, value_propFloat64);
+        m_SimpleInterface->setPropFloat64(value_propFloat64);
     }
     if(memberProperty == "propString") {
-        std::string propString = value.get<std::string>();
-        m_SimpleInterface->setPropString(propString);
+        std::string value_propString{};
+        ApiGear::ObjectLink::readValue(value, value_propString);
+        m_SimpleInterface->setPropString(value_propString);
     } 
 }
 
@@ -131,22 +142,21 @@ void SimpleInterfaceService::olinkUnlinked(const std::string& objectId){
     AG_LOG_DEBUG("SimpleInterfaceService unlinked " + objectId);
 }
 
-nlohmann::json SimpleInterfaceService::olinkCollectProperties()
+ApiGear::ObjectLink::OLinkContent SimpleInterfaceService::olinkCollectProperties()
 {
-    return nlohmann::json::object({
-        { "propBool", m_SimpleInterface->getPropBool() },
-        { "propInt", m_SimpleInterface->getPropInt() },
-        { "propInt32", m_SimpleInterface->getPropInt32() },
-        { "propInt64", m_SimpleInterface->getPropInt64() },
-        { "propFloat", m_SimpleInterface->getPropFloat() },
-        { "propFloat32", m_SimpleInterface->getPropFloat32() },
-        { "propFloat64", m_SimpleInterface->getPropFloat64() },
-        { "propString", m_SimpleInterface->getPropString() }
-    });
+    return ApiGear::ObjectLink::argumentsToContent(
+        ApiGear::ObjectLink::toInitialProperty(std::string("propBool"), m_SimpleInterface->getPropBool()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propInt"), m_SimpleInterface->getPropInt()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propInt32"), m_SimpleInterface->getPropInt32()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propInt64"), m_SimpleInterface->getPropInt64()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propFloat"), m_SimpleInterface->getPropFloat()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propFloat32"), m_SimpleInterface->getPropFloat32()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propFloat64"), m_SimpleInterface->getPropFloat64()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propString"), m_SimpleInterface->getPropString()) );
 }
 void SimpleInterfaceService::onSigBool(bool paramBool)
 {
-    const nlohmann::json args = { paramBool };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramBool);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -158,7 +168,7 @@ void SimpleInterfaceService::onSigBool(bool paramBool)
 }
 void SimpleInterfaceService::onSigInt(int paramInt)
 {
-    const nlohmann::json args = { paramInt };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramInt);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -170,7 +180,7 @@ void SimpleInterfaceService::onSigInt(int paramInt)
 }
 void SimpleInterfaceService::onSigInt32(int32_t paramInt32)
 {
-    const nlohmann::json args = { paramInt32 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramInt32);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt32");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -182,7 +192,7 @@ void SimpleInterfaceService::onSigInt32(int32_t paramInt32)
 }
 void SimpleInterfaceService::onSigInt64(int64_t paramInt64)
 {
-    const nlohmann::json args = { paramInt64 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramInt64);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt64");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -194,7 +204,7 @@ void SimpleInterfaceService::onSigInt64(int64_t paramInt64)
 }
 void SimpleInterfaceService::onSigFloat(float paramFloat)
 {
-    const nlohmann::json args = { paramFloat };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramFloat);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -206,7 +216,7 @@ void SimpleInterfaceService::onSigFloat(float paramFloat)
 }
 void SimpleInterfaceService::onSigFloat32(float paramFloa32)
 {
-    const nlohmann::json args = { paramFloa32 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramFloa32);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat32");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -218,7 +228,7 @@ void SimpleInterfaceService::onSigFloat32(float paramFloa32)
 }
 void SimpleInterfaceService::onSigFloat64(double paramFloat64)
 {
-    const nlohmann::json args = { paramFloat64 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramFloat64);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat64");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -230,7 +240,7 @@ void SimpleInterfaceService::onSigFloat64(double paramFloat64)
 }
 void SimpleInterfaceService::onSigString(const std::string& paramString)
 {
-    const nlohmann::json args = { paramString };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramString);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -247,7 +257,7 @@ void SimpleInterfaceService::onPropBoolChanged(bool propBool)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propBool);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propBool));
         }
     }
 }
@@ -258,7 +268,7 @@ void SimpleInterfaceService::onPropIntChanged(int propInt)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propInt);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propInt));
         }
     }
 }
@@ -269,7 +279,7 @@ void SimpleInterfaceService::onPropInt32Changed(int32_t propInt32)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propInt32);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propInt32));
         }
     }
 }
@@ -280,7 +290,7 @@ void SimpleInterfaceService::onPropInt64Changed(int64_t propInt64)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propInt64);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propInt64));
         }
     }
 }
@@ -291,7 +301,7 @@ void SimpleInterfaceService::onPropFloatChanged(float propFloat)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propFloat);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat));
         }
     }
 }
@@ -302,7 +312,7 @@ void SimpleInterfaceService::onPropFloat32Changed(float propFloat32)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propFloat32);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat32));
         }
     }
 }
@@ -313,7 +323,7 @@ void SimpleInterfaceService::onPropFloat64Changed(double propFloat64)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propFloat64);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat64));
         }
     }
 }
@@ -324,7 +334,7 @@ void SimpleInterfaceService::onPropStringChanged(const std::string& propString)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propString);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propString));
         }
     }
 }

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceservice.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/simpleinterfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to SimpleInterface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of SimpleInterface object.
     * @return the set of properties with their current values for the SimpleInterface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sigBool through network if the connection is established.
     */

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/voidinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/voidinterfaceclient.h
@@ -70,21 +70,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the VoidInterface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -92,16 +92,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from VoidInterface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
 
     /** 
     * An abstraction layer over the connection with service for the VoidInterfaceClient.

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/voidinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/voidinterfaceservice.cpp
@@ -6,6 +6,7 @@
 
 #include "olink/iremotenode.h"
 #include "olink/remoteregistry.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 #include <iostream>
@@ -35,18 +36,19 @@ std::string VoidInterfaceService::olinkObjectName() {
     return interfaceId;
 }
 
-nlohmann::json VoidInterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+ApiGear::ObjectLink::OLinkContent VoidInterfaceService::olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& fcnArgs) {
     (void) fcnArgs;
     AG_LOG_DEBUG("VoidInterfaceService invoke " + methodId);
     const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(fcnArgs);
     if(memberMethod == "funcVoid") {
         m_VoidInterface->funcVoid();
-        return nlohmann::json{};
+        return {};
     }
-    return nlohmann::json();
+    return {};
 }
 
-void VoidInterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+void VoidInterfaceService::olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) {
     AG_LOG_DEBUG("VoidInterfaceService set property " + propertyId);
     const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
     // no properties to set
@@ -62,14 +64,13 @@ void VoidInterfaceService::olinkUnlinked(const std::string& objectId){
     AG_LOG_DEBUG("VoidInterfaceService unlinked " + objectId);
 }
 
-nlohmann::json VoidInterfaceService::olinkCollectProperties()
+ApiGear::ObjectLink::OLinkContent VoidInterfaceService::olinkCollectProperties()
 {
-    return nlohmann::json::object({
-    });
+    return ApiGear::ObjectLink::argumentsToContent( );
 }
 void VoidInterfaceService::onSigVoid()
 {
-    const nlohmann::json args = {  };
+    auto args = ApiGear::ObjectLink::argumentsToContent();
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigVoid");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {

--- a/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/voidinterfaceservice.h
+++ b/goldenmaster/modules/tb_simple_module/tb_simple/generated/olink/voidinterfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to VoidInterface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of VoidInterface object.
     * @return the set of properties with their current values for the VoidInterface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sigVoid through network if the connection is established.
     */

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceclient.cpp
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "testbed1/generated/core/testbed1.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::Testbed1;
@@ -19,35 +20,27 @@ StructArrayInterfaceClient::StructArrayInterfaceClient()
     : m_publisher(std::make_unique<StructArrayInterfacePublisher>())
 {}
 
-void StructArrayInterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("propBool")) {
-        setPropBoolLocal(fields["propBool"].get<std::list<StructBool>>());
-    }
-    if(fields.contains("propInt")) {
-        setPropIntLocal(fields["propInt"].get<std::list<StructInt>>());
-    }
-    if(fields.contains("propFloat")) {
-        setPropFloatLocal(fields["propFloat"].get<std::list<StructFloat>>());
-    }
-    if(fields.contains("propString")) {
-        setPropStringLocal(fields["propString"].get<std::list<StructString>>());
-    }
-}
-
-void StructArrayInterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void StructArrayInterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "propBool") {
-        setPropBoolLocal(value.get<std::list<StructBool>>());
+        std::list<StructBool> value_propBool {};
+        readValue(value, value_propBool);
+        setPropBoolLocal(value_propBool);
     }
     else if ( propertyName == "propInt") {
-        setPropIntLocal(value.get<std::list<StructInt>>());
+        std::list<StructInt> value_propInt {};
+        readValue(value, value_propInt);
+        setPropIntLocal(value_propInt);
     }
     else if ( propertyName == "propFloat") {
-        setPropFloatLocal(value.get<std::list<StructFloat>>());
+        std::list<StructFloat> value_propFloat {};
+        readValue(value, value_propFloat);
+        setPropFloatLocal(value_propFloat);
     }
     else if ( propertyName == "propString") {
-        setPropStringLocal(value.get<std::list<StructString>>());
+        std::list<StructString> value_propString {};
+        readValue(value, value_propString);
+        setPropStringLocal(value_propString);
     }
 }
 
@@ -58,7 +51,7 @@ void StructArrayInterfaceClient::setPropBool(const std::list<StructBool>& propBo
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
-    m_node->setRemoteProperty(propertyId, propBool);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propBool));
 }
 
 void StructArrayInterfaceClient::setPropBoolLocal(const std::list<StructBool>& propBool)
@@ -81,7 +74,7 @@ void StructArrayInterfaceClient::setPropInt(const std::list<StructInt>& propInt)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
-    m_node->setRemoteProperty(propertyId, propInt);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propInt));
 }
 
 void StructArrayInterfaceClient::setPropIntLocal(const std::list<StructInt>& propInt)
@@ -104,7 +97,7 @@ void StructArrayInterfaceClient::setPropFloat(const std::list<StructFloat>& prop
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
-    m_node->setRemoteProperty(propertyId, propFloat);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat));
 }
 
 void StructArrayInterfaceClient::setPropFloatLocal(const std::list<StructFloat>& propFloat)
@@ -127,7 +120,7 @@ void StructArrayInterfaceClient::setPropString(const std::list<StructString>& pr
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
-    m_node->setRemoteProperty(propertyId, propString);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propString));
 }
 
 void StructArrayInterfaceClient::setPropStringLocal(const std::list<StructString>& propString)
@@ -164,10 +157,12 @@ std::future<StructBool> StructArrayInterfaceClient::funcBoolAsync(const std::lis
         {
             std::promise<StructBool> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramBool}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const StructBool& value = arg.value.get<StructBool>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramBool );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    StructBool result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -195,10 +190,12 @@ std::future<StructBool> StructArrayInterfaceClient::funcIntAsync(const std::list
         {
             std::promise<StructBool> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramInt}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const StructBool& value = arg.value.get<StructBool>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramInt );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    StructBool result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -226,10 +223,12 @@ std::future<StructBool> StructArrayInterfaceClient::funcFloatAsync(const std::li
         {
             std::promise<StructBool> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const StructBool& value = arg.value.get<StructBool>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramFloat );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    StructBool result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -257,10 +256,12 @@ std::future<StructBool> StructArrayInterfaceClient::funcStringAsync(const std::l
         {
             std::promise<StructBool> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramString}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const StructBool& value = arg.value.get<StructBool>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramString );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    StructBool result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -272,35 +273,43 @@ std::string StructArrayInterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void StructArrayInterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void StructArrayInterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sigBool") {
-        m_publisher->publishSigBool(args[0].get<std::list<StructBool>>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sigBool") {std::list<StructBool> arg_paramBool {};
+        argumentsReader.read(arg_paramBool);m_publisher->publishSigBool(arg_paramBool);   
         return;
     }
-    if(signalName == "sigInt") {
-        m_publisher->publishSigInt(args[0].get<std::list<StructInt>>());   
+    if(signalName == "sigInt") {std::list<StructInt> arg_paramInt {};
+        argumentsReader.read(arg_paramInt);m_publisher->publishSigInt(arg_paramInt);   
         return;
     }
-    if(signalName == "sigFloat") {
-        m_publisher->publishSigFloat(args[0].get<std::list<StructFloat>>());   
+    if(signalName == "sigFloat") {std::list<StructFloat> arg_paramFloat {};
+        argumentsReader.read(arg_paramFloat);m_publisher->publishSigFloat(arg_paramFloat);   
         return;
     }
-    if(signalName == "sigString") {
-        m_publisher->publishSigString(args[0].get<std::list<StructString>>());   
+    if(signalName == "sigString") {std::list<StructString> arg_paramString {};
+        argumentsReader.read(arg_paramString);m_publisher->publishSigString(arg_paramString);   
         return;
     }
 }
 
-void StructArrayInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void StructArrayInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void StructArrayInterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void StructArrayInterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void StructArrayInterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceclient.h
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceclient.h
@@ -137,21 +137,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the StructArrayInterface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -159,16 +159,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from StructArrayInterface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for PropBool and informs subscriber about the change*/
     void setPropBoolLocal(const std::list<StructBool>& propBool);
     /**  Updates local value for PropInt and informs subscriber about the change*/

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceservice.cpp
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceservice.cpp
@@ -6,6 +6,7 @@
 
 #include "olink/iremotenode.h"
 #include "olink/remoteregistry.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 #include <iostream>
@@ -35,50 +36,55 @@ std::string StructArrayInterfaceService::olinkObjectName() {
     return interfaceId;
 }
 
-nlohmann::json StructArrayInterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+ApiGear::ObjectLink::OLinkContent StructArrayInterfaceService::olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& fcnArgs) {
     AG_LOG_DEBUG("StructArrayInterfaceService invoke " + methodId);
     const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(fcnArgs);
     if(memberMethod == "funcBool") {
-        const std::list<StructBool>& paramBool = fcnArgs.at(0);
-        StructBool result = m_StructArrayInterface->funcBool(paramBool);
-        return result;
+        std::list<StructBool> paramBool{};
+        argumentsReader.read(paramBool);
+        return ApiGear::ObjectLink::invokeReturnValue(m_StructArrayInterface->funcBool(paramBool));
     }
     if(memberMethod == "funcInt") {
-        const std::list<StructInt>& paramInt = fcnArgs.at(0);
-        StructBool result = m_StructArrayInterface->funcInt(paramInt);
-        return result;
+        std::list<StructInt> paramInt{};
+        argumentsReader.read(paramInt);
+        return ApiGear::ObjectLink::invokeReturnValue(m_StructArrayInterface->funcInt(paramInt));
     }
     if(memberMethod == "funcFloat") {
-        const std::list<StructFloat>& paramFloat = fcnArgs.at(0);
-        StructBool result = m_StructArrayInterface->funcFloat(paramFloat);
-        return result;
+        std::list<StructFloat> paramFloat{};
+        argumentsReader.read(paramFloat);
+        return ApiGear::ObjectLink::invokeReturnValue(m_StructArrayInterface->funcFloat(paramFloat));
     }
     if(memberMethod == "funcString") {
-        const std::list<StructString>& paramString = fcnArgs.at(0);
-        StructBool result = m_StructArrayInterface->funcString(paramString);
-        return result;
+        std::list<StructString> paramString{};
+        argumentsReader.read(paramString);
+        return ApiGear::ObjectLink::invokeReturnValue(m_StructArrayInterface->funcString(paramString));
     }
-    return nlohmann::json();
+    return {};
 }
 
-void StructArrayInterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+void StructArrayInterfaceService::olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) {
     AG_LOG_DEBUG("StructArrayInterfaceService set property " + propertyId);
     const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
     if(memberProperty == "propBool") {
-        std::list<StructBool> propBool = value.get<std::list<StructBool>>();
-        m_StructArrayInterface->setPropBool(propBool);
+        std::list<StructBool> value_propBool{};
+        ApiGear::ObjectLink::readValue(value, value_propBool);
+        m_StructArrayInterface->setPropBool(value_propBool);
     }
     if(memberProperty == "propInt") {
-        std::list<StructInt> propInt = value.get<std::list<StructInt>>();
-        m_StructArrayInterface->setPropInt(propInt);
+        std::list<StructInt> value_propInt{};
+        ApiGear::ObjectLink::readValue(value, value_propInt);
+        m_StructArrayInterface->setPropInt(value_propInt);
     }
     if(memberProperty == "propFloat") {
-        std::list<StructFloat> propFloat = value.get<std::list<StructFloat>>();
-        m_StructArrayInterface->setPropFloat(propFloat);
+        std::list<StructFloat> value_propFloat{};
+        ApiGear::ObjectLink::readValue(value, value_propFloat);
+        m_StructArrayInterface->setPropFloat(value_propFloat);
     }
     if(memberProperty == "propString") {
-        std::list<StructString> propString = value.get<std::list<StructString>>();
-        m_StructArrayInterface->setPropString(propString);
+        std::list<StructString> value_propString{};
+        ApiGear::ObjectLink::readValue(value, value_propString);
+        m_StructArrayInterface->setPropString(value_propString);
     } 
 }
 
@@ -90,18 +96,17 @@ void StructArrayInterfaceService::olinkUnlinked(const std::string& objectId){
     AG_LOG_DEBUG("StructArrayInterfaceService unlinked " + objectId);
 }
 
-nlohmann::json StructArrayInterfaceService::olinkCollectProperties()
+ApiGear::ObjectLink::OLinkContent StructArrayInterfaceService::olinkCollectProperties()
 {
-    return nlohmann::json::object({
-        { "propBool", m_StructArrayInterface->getPropBool() },
-        { "propInt", m_StructArrayInterface->getPropInt() },
-        { "propFloat", m_StructArrayInterface->getPropFloat() },
-        { "propString", m_StructArrayInterface->getPropString() }
-    });
+    return ApiGear::ObjectLink::argumentsToContent(
+        ApiGear::ObjectLink::toInitialProperty(std::string("propBool"), m_StructArrayInterface->getPropBool()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propInt"), m_StructArrayInterface->getPropInt()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propFloat"), m_StructArrayInterface->getPropFloat()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("propString"), m_StructArrayInterface->getPropString()) );
 }
 void StructArrayInterfaceService::onSigBool(const std::list<StructBool>& paramBool)
 {
-    const nlohmann::json args = { paramBool };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramBool);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -113,7 +118,7 @@ void StructArrayInterfaceService::onSigBool(const std::list<StructBool>& paramBo
 }
 void StructArrayInterfaceService::onSigInt(const std::list<StructInt>& paramInt)
 {
-    const nlohmann::json args = { paramInt };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramInt);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -125,7 +130,7 @@ void StructArrayInterfaceService::onSigInt(const std::list<StructInt>& paramInt)
 }
 void StructArrayInterfaceService::onSigFloat(const std::list<StructFloat>& paramFloat)
 {
-    const nlohmann::json args = { paramFloat };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramFloat);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -137,7 +142,7 @@ void StructArrayInterfaceService::onSigFloat(const std::list<StructFloat>& param
 }
 void StructArrayInterfaceService::onSigString(const std::list<StructString>& paramString)
 {
-    const nlohmann::json args = { paramString };
+    auto args = ApiGear::ObjectLink::argumentsToContent(paramString);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -154,7 +159,7 @@ void StructArrayInterfaceService::onPropBoolChanged(const std::list<StructBool>&
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propBool);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propBool));
         }
     }
 }
@@ -165,7 +170,7 @@ void StructArrayInterfaceService::onPropIntChanged(const std::list<StructInt>& p
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propInt);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propInt));
         }
     }
 }
@@ -176,7 +181,7 @@ void StructArrayInterfaceService::onPropFloatChanged(const std::list<StructFloat
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propFloat);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat));
         }
     }
 }
@@ -187,7 +192,7 @@ void StructArrayInterfaceService::onPropStringChanged(const std::list<StructStri
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, propString);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(propString));
         }
     }
 }

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceservice.h
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structarrayinterfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to StructArrayInterface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of StructArrayInterface object.
     * @return the set of properties with their current values for the StructArrayInterface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sigBool through network if the connection is established.
     */

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structinterfaceclient.cpp
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structinterfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "testbed1/generated/core/testbed1.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::Testbed1;
@@ -19,35 +20,27 @@ StructInterfaceClient::StructInterfaceClient()
     : m_publisher(std::make_unique<StructInterfacePublisher>())
 {}
 
-void StructInterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("propBool")) {
-        setPropBoolLocal(fields["propBool"].get<StructBool>());
-    }
-    if(fields.contains("propInt")) {
-        setPropIntLocal(fields["propInt"].get<StructInt>());
-    }
-    if(fields.contains("propFloat")) {
-        setPropFloatLocal(fields["propFloat"].get<StructFloat>());
-    }
-    if(fields.contains("propString")) {
-        setPropStringLocal(fields["propString"].get<StructString>());
-    }
-}
-
-void StructInterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void StructInterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "propBool") {
-        setPropBoolLocal(value.get<StructBool>());
+        StructBool value_propBool {};
+        readValue(value, value_propBool);
+        setPropBoolLocal(value_propBool);
     }
     else if ( propertyName == "propInt") {
-        setPropIntLocal(value.get<StructInt>());
+        StructInt value_propInt {};
+        readValue(value, value_propInt);
+        setPropIntLocal(value_propInt);
     }
     else if ( propertyName == "propFloat") {
-        setPropFloatLocal(value.get<StructFloat>());
+        StructFloat value_propFloat {};
+        readValue(value, value_propFloat);
+        setPropFloatLocal(value_propFloat);
     }
     else if ( propertyName == "propString") {
-        setPropStringLocal(value.get<StructString>());
+        StructString value_propString {};
+        readValue(value, value_propString);
+        setPropStringLocal(value_propString);
     }
 }
 
@@ -58,7 +51,7 @@ void StructInterfaceClient::setPropBool(const StructBool& propBool)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
-    m_node->setRemoteProperty(propertyId, propBool);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propBool));
 }
 
 void StructInterfaceClient::setPropBoolLocal(const StructBool& propBool)
@@ -81,7 +74,7 @@ void StructInterfaceClient::setPropInt(const StructInt& propInt)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
-    m_node->setRemoteProperty(propertyId, propInt);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propInt));
 }
 
 void StructInterfaceClient::setPropIntLocal(const StructInt& propInt)
@@ -104,7 +97,7 @@ void StructInterfaceClient::setPropFloat(const StructFloat& propFloat)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
-    m_node->setRemoteProperty(propertyId, propFloat);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propFloat));
 }
 
 void StructInterfaceClient::setPropFloatLocal(const StructFloat& propFloat)
@@ -127,7 +120,7 @@ void StructInterfaceClient::setPropString(const StructString& propString)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
-    m_node->setRemoteProperty(propertyId, propString);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(propString));
 }
 
 void StructInterfaceClient::setPropStringLocal(const StructString& propString)
@@ -164,10 +157,12 @@ std::future<StructBool> StructInterfaceClient::funcBoolAsync(const StructBool& p
         {
             std::promise<StructBool> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramBool}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const StructBool& value = arg.value.get<StructBool>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramBool );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    StructBool result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -195,10 +190,12 @@ std::future<StructBool> StructInterfaceClient::funcIntAsync(const StructInt& par
         {
             std::promise<StructBool> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramInt}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const StructBool& value = arg.value.get<StructBool>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramInt );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    StructBool result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -226,10 +223,12 @@ std::future<StructFloat> StructInterfaceClient::funcFloatAsync(const StructFloat
         {
             std::promise<StructFloat> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const StructFloat& value = arg.value.get<StructFloat>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramFloat );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    StructFloat result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -257,10 +256,12 @@ std::future<StructString> StructInterfaceClient::funcStringAsync(const StructStr
         {
             std::promise<StructString> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({paramString}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const StructString& value = arg.value.get<StructString>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( paramString );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    StructString result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -272,35 +273,43 @@ std::string StructInterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void StructInterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void StructInterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sigBool") {
-        m_publisher->publishSigBool(args[0].get<StructBool>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sigBool") {StructBool arg_paramBool {};
+        argumentsReader.read(arg_paramBool);m_publisher->publishSigBool(arg_paramBool);   
         return;
     }
-    if(signalName == "sigInt") {
-        m_publisher->publishSigInt(args[0].get<StructInt>());   
+    if(signalName == "sigInt") {StructInt arg_paramInt {};
+        argumentsReader.read(arg_paramInt);m_publisher->publishSigInt(arg_paramInt);   
         return;
     }
-    if(signalName == "sigFloat") {
-        m_publisher->publishSigFloat(args[0].get<StructFloat>());   
+    if(signalName == "sigFloat") {StructFloat arg_paramFloat {};
+        argumentsReader.read(arg_paramFloat);m_publisher->publishSigFloat(arg_paramFloat);   
         return;
     }
-    if(signalName == "sigString") {
-        m_publisher->publishSigString(args[0].get<StructString>());   
+    if(signalName == "sigString") {StructString arg_paramString {};
+        argumentsReader.read(arg_paramString);m_publisher->publishSigString(arg_paramString);   
         return;
     }
 }
 
-void StructInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void StructInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void StructInterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void StructInterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void StructInterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structinterfaceclient.h
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structinterfaceclient.h
@@ -137,21 +137,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the StructInterface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -159,16 +159,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from StructInterface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for PropBool and informs subscriber about the change*/
     void setPropBoolLocal(const StructBool& propBool);
     /**  Updates local value for PropInt and informs subscriber about the change*/

--- a/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structinterfaceservice.h
+++ b/goldenmaster/modules/testbed1_module/testbed1/generated/olink/structinterfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to StructInterface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of StructInterface object.
     * @return the set of properties with their current values for the StructInterface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sigBool through network if the connection is established.
     */

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceclient.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "testbed2/generated/core/testbed2.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::Testbed2;
@@ -19,35 +20,27 @@ ManyParamInterfaceClient::ManyParamInterfaceClient()
     : m_publisher(std::make_unique<ManyParamInterfacePublisher>())
 {}
 
-void ManyParamInterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("prop1")) {
-        setProp1Local(fields["prop1"].get<int>());
-    }
-    if(fields.contains("prop2")) {
-        setProp2Local(fields["prop2"].get<int>());
-    }
-    if(fields.contains("prop3")) {
-        setProp3Local(fields["prop3"].get<int>());
-    }
-    if(fields.contains("prop4")) {
-        setProp4Local(fields["prop4"].get<int>());
-    }
-}
-
-void ManyParamInterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void ManyParamInterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "prop1") {
-        setProp1Local(value.get<int>());
+        int value_prop1 {};
+        readValue(value, value_prop1);
+        setProp1Local(value_prop1);
     }
     else if ( propertyName == "prop2") {
-        setProp2Local(value.get<int>());
+        int value_prop2 {};
+        readValue(value, value_prop2);
+        setProp2Local(value_prop2);
     }
     else if ( propertyName == "prop3") {
-        setProp3Local(value.get<int>());
+        int value_prop3 {};
+        readValue(value, value_prop3);
+        setProp3Local(value_prop3);
     }
     else if ( propertyName == "prop4") {
-        setProp4Local(value.get<int>());
+        int value_prop4 {};
+        readValue(value, value_prop4);
+        setProp4Local(value_prop4);
     }
 }
 
@@ -58,7 +51,7 @@ void ManyParamInterfaceClient::setProp1(int prop1)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    m_node->setRemoteProperty(propertyId, prop1);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
 }
 
 void ManyParamInterfaceClient::setProp1Local(int prop1)
@@ -81,7 +74,7 @@ void ManyParamInterfaceClient::setProp2(int prop2)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    m_node->setRemoteProperty(propertyId, prop2);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop2));
 }
 
 void ManyParamInterfaceClient::setProp2Local(int prop2)
@@ -104,7 +97,7 @@ void ManyParamInterfaceClient::setProp3(int prop3)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
-    m_node->setRemoteProperty(propertyId, prop3);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop3));
 }
 
 void ManyParamInterfaceClient::setProp3Local(int prop3)
@@ -127,7 +120,7 @@ void ManyParamInterfaceClient::setProp4(int prop4)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop4");
-    m_node->setRemoteProperty(propertyId, prop4);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop4));
 }
 
 void ManyParamInterfaceClient::setProp4Local(int prop4)
@@ -164,10 +157,12 @@ std::future<int> ManyParamInterfaceClient::func1Async(int param1)
         {
             std::promise<int> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const int& value = arg.value.get<int>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    int result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -196,10 +191,12 @@ std::future<int> ManyParamInterfaceClient::func2Async(int param1, int param2)
         {
             std::promise<int> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const int& value = arg.value.get<int>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1, param2 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    int result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -229,10 +226,12 @@ std::future<int> ManyParamInterfaceClient::func3Async(int param1, int param2, in
         {
             std::promise<int> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func3");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1, param2, param3}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const int& value = arg.value.get<int>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1, param2, param3 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    int result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -263,10 +262,12 @@ std::future<int> ManyParamInterfaceClient::func4Async(int param1, int param2, in
         {
             std::promise<int> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func4");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1, param2, param3, param4}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const int& value = arg.value.get<int>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1, param2, param3, param4 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    int result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -278,35 +279,49 @@ std::string ManyParamInterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void ManyParamInterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void ManyParamInterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sig1") {
-        m_publisher->publishSig1(args[0].get<int>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sig1") {int arg_param1 {};
+        argumentsReader.read(arg_param1);m_publisher->publishSig1(arg_param1);   
         return;
     }
-    if(signalName == "sig2") {
-        m_publisher->publishSig2(args[0].get<int>(),args[1].get<int>());   
+    if(signalName == "sig2") {int arg_param1 {};
+        argumentsReader.read(arg_param1);int arg_param2 {};
+        argumentsReader.read(arg_param2);m_publisher->publishSig2(arg_param1,arg_param2);   
         return;
     }
-    if(signalName == "sig3") {
-        m_publisher->publishSig3(args[0].get<int>(),args[1].get<int>(),args[2].get<int>());   
+    if(signalName == "sig3") {int arg_param1 {};
+        argumentsReader.read(arg_param1);int arg_param2 {};
+        argumentsReader.read(arg_param2);int arg_param3 {};
+        argumentsReader.read(arg_param3);m_publisher->publishSig3(arg_param1,arg_param2,arg_param3);   
         return;
     }
-    if(signalName == "sig4") {
-        m_publisher->publishSig4(args[0].get<int>(),args[1].get<int>(),args[2].get<int>(),args[3].get<int>());   
+    if(signalName == "sig4") {int arg_param1 {};
+        argumentsReader.read(arg_param1);int arg_param2 {};
+        argumentsReader.read(arg_param2);int arg_param3 {};
+        argumentsReader.read(arg_param3);int arg_param4 {};
+        argumentsReader.read(arg_param4);m_publisher->publishSig4(arg_param1,arg_param2,arg_param3,arg_param4);   
         return;
     }
 }
 
-void ManyParamInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void ManyParamInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void ManyParamInterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void ManyParamInterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void ManyParamInterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceclient.h
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceclient.h
@@ -137,21 +137,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the ManyParamInterface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -159,16 +159,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from ManyParamInterface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop1 and informs subscriber about the change*/
     void setProp1Local(int prop1);
     /**  Updates local value for Prop2 and informs subscriber about the change*/

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceservice.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceservice.cpp
@@ -6,6 +6,7 @@
 
 #include "olink/iremotenode.h"
 #include "olink/remoteregistry.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 #include <iostream>
@@ -35,56 +36,67 @@ std::string ManyParamInterfaceService::olinkObjectName() {
     return interfaceId;
 }
 
-nlohmann::json ManyParamInterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+ApiGear::ObjectLink::OLinkContent ManyParamInterfaceService::olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& fcnArgs) {
     AG_LOG_DEBUG("ManyParamInterfaceService invoke " + methodId);
     const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(fcnArgs);
     if(memberMethod == "func1") {
-        const int& param1 = fcnArgs.at(0);
-        int result = m_ManyParamInterface->func1(param1);
-        return result;
+        int param1{};
+        argumentsReader.read(param1);
+        return ApiGear::ObjectLink::invokeReturnValue(m_ManyParamInterface->func1(param1));
     }
     if(memberMethod == "func2") {
-        const int& param1 = fcnArgs.at(0);
-        const int& param2 = fcnArgs.at(1);
-        int result = m_ManyParamInterface->func2(param1, param2);
-        return result;
+        int param1{};
+        argumentsReader.read(param1);
+        int param2{};
+        argumentsReader.read(param2);
+        return ApiGear::ObjectLink::invokeReturnValue(m_ManyParamInterface->func2(param1, param2));
     }
     if(memberMethod == "func3") {
-        const int& param1 = fcnArgs.at(0);
-        const int& param2 = fcnArgs.at(1);
-        const int& param3 = fcnArgs.at(2);
-        int result = m_ManyParamInterface->func3(param1, param2, param3);
-        return result;
+        int param1{};
+        argumentsReader.read(param1);
+        int param2{};
+        argumentsReader.read(param2);
+        int param3{};
+        argumentsReader.read(param3);
+        return ApiGear::ObjectLink::invokeReturnValue(m_ManyParamInterface->func3(param1, param2, param3));
     }
     if(memberMethod == "func4") {
-        const int& param1 = fcnArgs.at(0);
-        const int& param2 = fcnArgs.at(1);
-        const int& param3 = fcnArgs.at(2);
-        const int& param4 = fcnArgs.at(3);
-        int result = m_ManyParamInterface->func4(param1, param2, param3, param4);
-        return result;
+        int param1{};
+        argumentsReader.read(param1);
+        int param2{};
+        argumentsReader.read(param2);
+        int param3{};
+        argumentsReader.read(param3);
+        int param4{};
+        argumentsReader.read(param4);
+        return ApiGear::ObjectLink::invokeReturnValue(m_ManyParamInterface->func4(param1, param2, param3, param4));
     }
-    return nlohmann::json();
+    return {};
 }
 
-void ManyParamInterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+void ManyParamInterfaceService::olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) {
     AG_LOG_DEBUG("ManyParamInterfaceService set property " + propertyId);
     const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
     if(memberProperty == "prop1") {
-        int prop1 = value.get<int>();
-        m_ManyParamInterface->setProp1(prop1);
+        int value_prop1{};
+        ApiGear::ObjectLink::readValue(value, value_prop1);
+        m_ManyParamInterface->setProp1(value_prop1);
     }
     if(memberProperty == "prop2") {
-        int prop2 = value.get<int>();
-        m_ManyParamInterface->setProp2(prop2);
+        int value_prop2{};
+        ApiGear::ObjectLink::readValue(value, value_prop2);
+        m_ManyParamInterface->setProp2(value_prop2);
     }
     if(memberProperty == "prop3") {
-        int prop3 = value.get<int>();
-        m_ManyParamInterface->setProp3(prop3);
+        int value_prop3{};
+        ApiGear::ObjectLink::readValue(value, value_prop3);
+        m_ManyParamInterface->setProp3(value_prop3);
     }
     if(memberProperty == "prop4") {
-        int prop4 = value.get<int>();
-        m_ManyParamInterface->setProp4(prop4);
+        int value_prop4{};
+        ApiGear::ObjectLink::readValue(value, value_prop4);
+        m_ManyParamInterface->setProp4(value_prop4);
     } 
 }
 
@@ -96,18 +108,17 @@ void ManyParamInterfaceService::olinkUnlinked(const std::string& objectId){
     AG_LOG_DEBUG("ManyParamInterfaceService unlinked " + objectId);
 }
 
-nlohmann::json ManyParamInterfaceService::olinkCollectProperties()
+ApiGear::ObjectLink::OLinkContent ManyParamInterfaceService::olinkCollectProperties()
 {
-    return nlohmann::json::object({
-        { "prop1", m_ManyParamInterface->getProp1() },
-        { "prop2", m_ManyParamInterface->getProp2() },
-        { "prop3", m_ManyParamInterface->getProp3() },
-        { "prop4", m_ManyParamInterface->getProp4() }
-    });
+    return ApiGear::ObjectLink::argumentsToContent(
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop1"), m_ManyParamInterface->getProp1()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop2"), m_ManyParamInterface->getProp2()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop3"), m_ManyParamInterface->getProp3()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop4"), m_ManyParamInterface->getProp4()) );
 }
 void ManyParamInterfaceService::onSig1(int param1)
 {
-    const nlohmann::json args = { param1 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -119,7 +130,7 @@ void ManyParamInterfaceService::onSig1(int param1)
 }
 void ManyParamInterfaceService::onSig2(int param1, int param2)
 {
-    const nlohmann::json args = { param1, param2 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1, param2);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -131,7 +142,7 @@ void ManyParamInterfaceService::onSig2(int param1, int param2)
 }
 void ManyParamInterfaceService::onSig3(int param1, int param2, int param3)
 {
-    const nlohmann::json args = { param1, param2, param3 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1, param2, param3);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig3");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -143,7 +154,7 @@ void ManyParamInterfaceService::onSig3(int param1, int param2, int param3)
 }
 void ManyParamInterfaceService::onSig4(int param1, int param2, int param3, int param4)
 {
-    const nlohmann::json args = { param1, param2, param3, param4 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1, param2, param3, param4);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig4");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -160,7 +171,7 @@ void ManyParamInterfaceService::onProp1Changed(int prop1)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop1);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
         }
     }
 }
@@ -171,7 +182,7 @@ void ManyParamInterfaceService::onProp2Changed(int prop2)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop2);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop2));
         }
     }
 }
@@ -182,7 +193,7 @@ void ManyParamInterfaceService::onProp3Changed(int prop3)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop3);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop3));
         }
     }
 }
@@ -193,7 +204,7 @@ void ManyParamInterfaceService::onProp4Changed(int prop4)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop4);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop4));
         }
     }
 }

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceservice.h
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/manyparaminterfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to ManyParamInterface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of ManyParamInterface object.
     * @return the set of properties with their current values for the ManyParamInterface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig1 through network if the connection is established.
     */

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct1interfaceclient.h
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct1interfaceclient.h
@@ -80,21 +80,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the NestedStruct1Interface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -102,16 +102,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from NestedStruct1Interface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop1 and informs subscriber about the change*/
     void setProp1Local(const NestedStruct1& prop1);
 

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct1interfaceservice.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct1interfaceservice.cpp
@@ -6,6 +6,7 @@
 
 #include "olink/iremotenode.h"
 #include "olink/remoteregistry.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 #include <iostream>
@@ -35,23 +36,25 @@ std::string NestedStruct1InterfaceService::olinkObjectName() {
     return interfaceId;
 }
 
-nlohmann::json NestedStruct1InterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+ApiGear::ObjectLink::OLinkContent NestedStruct1InterfaceService::olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& fcnArgs) {
     AG_LOG_DEBUG("NestedStruct1InterfaceService invoke " + methodId);
     const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(fcnArgs);
     if(memberMethod == "func1") {
-        const NestedStruct1& param1 = fcnArgs.at(0);
-        NestedStruct1 result = m_NestedStruct1Interface->func1(param1);
-        return result;
+        NestedStruct1 param1{};
+        argumentsReader.read(param1);
+        return ApiGear::ObjectLink::invokeReturnValue(m_NestedStruct1Interface->func1(param1));
     }
-    return nlohmann::json();
+    return {};
 }
 
-void NestedStruct1InterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+void NestedStruct1InterfaceService::olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) {
     AG_LOG_DEBUG("NestedStruct1InterfaceService set property " + propertyId);
     const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
     if(memberProperty == "prop1") {
-        NestedStruct1 prop1 = value.get<NestedStruct1>();
-        m_NestedStruct1Interface->setProp1(prop1);
+        NestedStruct1 value_prop1{};
+        ApiGear::ObjectLink::readValue(value, value_prop1);
+        m_NestedStruct1Interface->setProp1(value_prop1);
     } 
 }
 
@@ -63,15 +66,14 @@ void NestedStruct1InterfaceService::olinkUnlinked(const std::string& objectId){
     AG_LOG_DEBUG("NestedStruct1InterfaceService unlinked " + objectId);
 }
 
-nlohmann::json NestedStruct1InterfaceService::olinkCollectProperties()
+ApiGear::ObjectLink::OLinkContent NestedStruct1InterfaceService::olinkCollectProperties()
 {
-    return nlohmann::json::object({
-        { "prop1", m_NestedStruct1Interface->getProp1() }
-    });
+    return ApiGear::ObjectLink::argumentsToContent(
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop1"), m_NestedStruct1Interface->getProp1()) );
 }
 void NestedStruct1InterfaceService::onSig1(const NestedStruct1& param1)
 {
-    const nlohmann::json args = { param1 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -88,7 +90,7 @@ void NestedStruct1InterfaceService::onProp1Changed(const NestedStruct1& prop1)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop1);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
         }
     }
 }

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct1interfaceservice.h
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct1interfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to NestedStruct1Interface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of NestedStruct1Interface object.
     * @return the set of properties with their current values for the NestedStruct1Interface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig1 through network if the connection is established.
     */

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceclient.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "testbed2/generated/core/testbed2.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::Testbed2;
@@ -19,23 +20,17 @@ NestedStruct2InterfaceClient::NestedStruct2InterfaceClient()
     : m_publisher(std::make_unique<NestedStruct2InterfacePublisher>())
 {}
 
-void NestedStruct2InterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("prop1")) {
-        setProp1Local(fields["prop1"].get<NestedStruct1>());
-    }
-    if(fields.contains("prop2")) {
-        setProp2Local(fields["prop2"].get<NestedStruct2>());
-    }
-}
-
-void NestedStruct2InterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void NestedStruct2InterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "prop1") {
-        setProp1Local(value.get<NestedStruct1>());
+        NestedStruct1 value_prop1 {};
+        readValue(value, value_prop1);
+        setProp1Local(value_prop1);
     }
     else if ( propertyName == "prop2") {
-        setProp2Local(value.get<NestedStruct2>());
+        NestedStruct2 value_prop2 {};
+        readValue(value, value_prop2);
+        setProp2Local(value_prop2);
     }
 }
 
@@ -46,7 +41,7 @@ void NestedStruct2InterfaceClient::setProp1(const NestedStruct1& prop1)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    m_node->setRemoteProperty(propertyId, prop1);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
 }
 
 void NestedStruct2InterfaceClient::setProp1Local(const NestedStruct1& prop1)
@@ -69,7 +64,7 @@ void NestedStruct2InterfaceClient::setProp2(const NestedStruct2& prop2)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    m_node->setRemoteProperty(propertyId, prop2);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop2));
 }
 
 void NestedStruct2InterfaceClient::setProp2Local(const NestedStruct2& prop2)
@@ -106,10 +101,12 @@ std::future<NestedStruct1> NestedStruct2InterfaceClient::func1Async(const Nested
         {
             std::promise<NestedStruct1> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const NestedStruct1& value = arg.value.get<NestedStruct1>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    NestedStruct1 result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -138,10 +135,12 @@ std::future<NestedStruct1> NestedStruct2InterfaceClient::func2Async(const Nested
         {
             std::promise<NestedStruct1> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const NestedStruct1& value = arg.value.get<NestedStruct1>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1, param2 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    NestedStruct1 result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -153,27 +152,36 @@ std::string NestedStruct2InterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void NestedStruct2InterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void NestedStruct2InterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sig1") {
-        m_publisher->publishSig1(args[0].get<NestedStruct1>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sig1") {NestedStruct1 arg_param1 {};
+        argumentsReader.read(arg_param1);m_publisher->publishSig1(arg_param1);   
         return;
     }
-    if(signalName == "sig2") {
-        m_publisher->publishSig2(args[0].get<NestedStruct1>(),args[1].get<NestedStruct2>());   
+    if(signalName == "sig2") {NestedStruct1 arg_param1 {};
+        argumentsReader.read(arg_param1);NestedStruct2 arg_param2 {};
+        argumentsReader.read(arg_param2);m_publisher->publishSig2(arg_param1,arg_param2);   
         return;
     }
 }
 
-void NestedStruct2InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void NestedStruct2InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void NestedStruct2InterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void NestedStruct2InterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void NestedStruct2InterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceclient.h
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceclient.h
@@ -99,21 +99,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the NestedStruct2Interface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -121,16 +121,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from NestedStruct2Interface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop1 and informs subscriber about the change*/
     void setProp1Local(const NestedStruct1& prop1);
     /**  Updates local value for Prop2 and informs subscriber about the change*/

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceservice.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceservice.cpp
@@ -6,6 +6,7 @@
 
 #include "olink/iremotenode.h"
 #include "olink/remoteregistry.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 #include <iostream>
@@ -35,33 +36,37 @@ std::string NestedStruct2InterfaceService::olinkObjectName() {
     return interfaceId;
 }
 
-nlohmann::json NestedStruct2InterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+ApiGear::ObjectLink::OLinkContent NestedStruct2InterfaceService::olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& fcnArgs) {
     AG_LOG_DEBUG("NestedStruct2InterfaceService invoke " + methodId);
     const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(fcnArgs);
     if(memberMethod == "func1") {
-        const NestedStruct1& param1 = fcnArgs.at(0);
-        NestedStruct1 result = m_NestedStruct2Interface->func1(param1);
-        return result;
+        NestedStruct1 param1{};
+        argumentsReader.read(param1);
+        return ApiGear::ObjectLink::invokeReturnValue(m_NestedStruct2Interface->func1(param1));
     }
     if(memberMethod == "func2") {
-        const NestedStruct1& param1 = fcnArgs.at(0);
-        const NestedStruct2& param2 = fcnArgs.at(1);
-        NestedStruct1 result = m_NestedStruct2Interface->func2(param1, param2);
-        return result;
+        NestedStruct1 param1{};
+        argumentsReader.read(param1);
+        NestedStruct2 param2{};
+        argumentsReader.read(param2);
+        return ApiGear::ObjectLink::invokeReturnValue(m_NestedStruct2Interface->func2(param1, param2));
     }
-    return nlohmann::json();
+    return {};
 }
 
-void NestedStruct2InterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+void NestedStruct2InterfaceService::olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) {
     AG_LOG_DEBUG("NestedStruct2InterfaceService set property " + propertyId);
     const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
     if(memberProperty == "prop1") {
-        NestedStruct1 prop1 = value.get<NestedStruct1>();
-        m_NestedStruct2Interface->setProp1(prop1);
+        NestedStruct1 value_prop1{};
+        ApiGear::ObjectLink::readValue(value, value_prop1);
+        m_NestedStruct2Interface->setProp1(value_prop1);
     }
     if(memberProperty == "prop2") {
-        NestedStruct2 prop2 = value.get<NestedStruct2>();
-        m_NestedStruct2Interface->setProp2(prop2);
+        NestedStruct2 value_prop2{};
+        ApiGear::ObjectLink::readValue(value, value_prop2);
+        m_NestedStruct2Interface->setProp2(value_prop2);
     } 
 }
 
@@ -73,16 +78,15 @@ void NestedStruct2InterfaceService::olinkUnlinked(const std::string& objectId){
     AG_LOG_DEBUG("NestedStruct2InterfaceService unlinked " + objectId);
 }
 
-nlohmann::json NestedStruct2InterfaceService::olinkCollectProperties()
+ApiGear::ObjectLink::OLinkContent NestedStruct2InterfaceService::olinkCollectProperties()
 {
-    return nlohmann::json::object({
-        { "prop1", m_NestedStruct2Interface->getProp1() },
-        { "prop2", m_NestedStruct2Interface->getProp2() }
-    });
+    return ApiGear::ObjectLink::argumentsToContent(
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop1"), m_NestedStruct2Interface->getProp1()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop2"), m_NestedStruct2Interface->getProp2()) );
 }
 void NestedStruct2InterfaceService::onSig1(const NestedStruct1& param1)
 {
-    const nlohmann::json args = { param1 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -94,7 +98,7 @@ void NestedStruct2InterfaceService::onSig1(const NestedStruct1& param1)
 }
 void NestedStruct2InterfaceService::onSig2(const NestedStruct1& param1, const NestedStruct2& param2)
 {
-    const nlohmann::json args = { param1, param2 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1, param2);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -111,7 +115,7 @@ void NestedStruct2InterfaceService::onProp1Changed(const NestedStruct1& prop1)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop1);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
         }
     }
 }
@@ -122,7 +126,7 @@ void NestedStruct2InterfaceService::onProp2Changed(const NestedStruct2& prop2)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop2);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop2));
         }
     }
 }

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceservice.h
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct2interfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to NestedStruct2Interface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of NestedStruct2Interface object.
     * @return the set of properties with their current values for the NestedStruct2Interface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig1 through network if the connection is established.
     */

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceclient.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceclient.cpp
@@ -5,6 +5,7 @@
 #include "testbed2/generated/core/testbed2.json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 using namespace Test::Testbed2;
@@ -19,29 +20,22 @@ NestedStruct3InterfaceClient::NestedStruct3InterfaceClient()
     : m_publisher(std::make_unique<NestedStruct3InterfacePublisher>())
 {}
 
-void NestedStruct3InterfaceClient::applyState(const nlohmann::json& fields) 
-{
-    if(fields.contains("prop1")) {
-        setProp1Local(fields["prop1"].get<NestedStruct1>());
-    }
-    if(fields.contains("prop2")) {
-        setProp2Local(fields["prop2"].get<NestedStruct2>());
-    }
-    if(fields.contains("prop3")) {
-        setProp3Local(fields["prop3"].get<NestedStruct3>());
-    }
-}
-
-void NestedStruct3InterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+void NestedStruct3InterfaceClient::applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value)
 {
     if ( propertyName == "prop1") {
-        setProp1Local(value.get<NestedStruct1>());
+        NestedStruct1 value_prop1 {};
+        readValue(value, value_prop1);
+        setProp1Local(value_prop1);
     }
     else if ( propertyName == "prop2") {
-        setProp2Local(value.get<NestedStruct2>());
+        NestedStruct2 value_prop2 {};
+        readValue(value, value_prop2);
+        setProp2Local(value_prop2);
     }
     else if ( propertyName == "prop3") {
-        setProp3Local(value.get<NestedStruct3>());
+        NestedStruct3 value_prop3 {};
+        readValue(value, value_prop3);
+        setProp3Local(value_prop3);
     }
 }
 
@@ -52,7 +46,7 @@ void NestedStruct3InterfaceClient::setProp1(const NestedStruct1& prop1)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop1");
-    m_node->setRemoteProperty(propertyId, prop1);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
 }
 
 void NestedStruct3InterfaceClient::setProp1Local(const NestedStruct1& prop1)
@@ -75,7 +69,7 @@ void NestedStruct3InterfaceClient::setProp2(const NestedStruct2& prop2)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop2");
-    m_node->setRemoteProperty(propertyId, prop2);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop2));
 }
 
 void NestedStruct3InterfaceClient::setProp2Local(const NestedStruct2& prop2)
@@ -98,7 +92,7 @@ void NestedStruct3InterfaceClient::setProp3(const NestedStruct3& prop3)
         return;
     }
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "prop3");
-    m_node->setRemoteProperty(propertyId, prop3);
+    m_node->setRemoteProperty(propertyId, ApiGear::ObjectLink::propertyToContent(prop3));
 }
 
 void NestedStruct3InterfaceClient::setProp3Local(const NestedStruct3& prop3)
@@ -135,10 +129,12 @@ std::future<NestedStruct1> NestedStruct3InterfaceClient::func1Async(const Nested
         {
             std::promise<NestedStruct1> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func1");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const NestedStruct1& value = arg.value.get<NestedStruct1>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    NestedStruct1 result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -167,10 +163,12 @@ std::future<NestedStruct1> NestedStruct3InterfaceClient::func2Async(const Nested
         {
             std::promise<NestedStruct1> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func2");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1, param2}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const NestedStruct1& value = arg.value.get<NestedStruct1>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1, param2 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    NestedStruct1 result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -200,10 +198,12 @@ std::future<NestedStruct1> NestedStruct3InterfaceClient::func3Async(const Nested
         {
             std::promise<NestedStruct1> resultPromise;
             static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "func3");
-            m_node->invokeRemote(operationId,
-                nlohmann::json::array({param1, param2, param3}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
-                    const NestedStruct1& value = arg.value.get<NestedStruct1>();
-                    resultPromise.set_value(value);
+            auto args = ApiGear::ObjectLink::argumentsToContent( param1, param2, param3 );
+            m_node->invokeRemote(operationId, args,
+                   [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    NestedStruct1 result{};
+                    readValue(arg.value, result);
+                    resultPromise.set_value(result);
                 });
             return resultPromise.get_future().get();
         }
@@ -215,31 +215,42 @@ std::string NestedStruct3InterfaceClient::olinkObjectName()
     return interfaceId;
 }
 
-void NestedStruct3InterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+void NestedStruct3InterfaceClient::olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args)
 {
     const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
-    if(signalName == "sig1") {
-        m_publisher->publishSig1(args[0].get<NestedStruct1>());   
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(args);
+    if(signalName == "sig1") {NestedStruct1 arg_param1 {};
+        argumentsReader.read(arg_param1);m_publisher->publishSig1(arg_param1);   
         return;
     }
-    if(signalName == "sig2") {
-        m_publisher->publishSig2(args[0].get<NestedStruct1>(),args[1].get<NestedStruct2>());   
+    if(signalName == "sig2") {NestedStruct1 arg_param1 {};
+        argumentsReader.read(arg_param1);NestedStruct2 arg_param2 {};
+        argumentsReader.read(arg_param2);m_publisher->publishSig2(arg_param1,arg_param2);   
         return;
     }
-    if(signalName == "sig3") {
-        m_publisher->publishSig3(args[0].get<NestedStruct1>(),args[1].get<NestedStruct2>(),args[2].get<NestedStruct3>());   
+    if(signalName == "sig3") {NestedStruct1 arg_param1 {};
+        argumentsReader.read(arg_param1);NestedStruct2 arg_param2 {};
+        argumentsReader.read(arg_param2);NestedStruct3 arg_param3 {};
+        argumentsReader.read(arg_param3);m_publisher->publishSig3(arg_param1,arg_param2,arg_param3);   
         return;
     }
 }
 
-void NestedStruct3InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+void NestedStruct3InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value)
 {
     applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
 }
-void NestedStruct3InterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+void NestedStruct3InterfaceClient::olinkOnInit(const std::string& /*name*/, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node)
 {
     m_node = node;
-    applyState(props);
+    ApiGear::ObjectLink::OLinContentStreamReader reader(props);
+    size_t propertyCount = reader.argumentsCount();
+    ApiGear::ObjectLink::InitialProperty currentProperty;
+    for (size_t i = 0; i < propertyCount; i++)
+    {
+        reader.read(currentProperty);
+        applyProperty(currentProperty.propertyName, currentProperty.propertyValue);
+    }
 }
 
 void NestedStruct3InterfaceClient::olinkOnRelease()

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceclient.h
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceclient.h
@@ -118,21 +118,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the NestedStruct3Interface service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -140,16 +140,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from NestedStruct3Interface service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
     /**  Updates local value for Prop1 and informs subscriber about the change*/
     void setProp1Local(const NestedStruct1& prop1);
     /**  Updates local value for Prop2 and informs subscriber about the change*/

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceservice.cpp
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceservice.cpp
@@ -6,6 +6,7 @@
 
 #include "olink/iremotenode.h"
 #include "olink/remoteregistry.h"
+#include "olink/core/olinkcontent.h"
 #include "apigear/utilities/logger.h"
 
 #include <iostream>
@@ -35,44 +36,51 @@ std::string NestedStruct3InterfaceService::olinkObjectName() {
     return interfaceId;
 }
 
-nlohmann::json NestedStruct3InterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+ApiGear::ObjectLink::OLinkContent NestedStruct3InterfaceService::olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& fcnArgs) {
     AG_LOG_DEBUG("NestedStruct3InterfaceService invoke " + methodId);
     const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    ApiGear::ObjectLink::OLinContentStreamReader argumentsReader(fcnArgs);
     if(memberMethod == "func1") {
-        const NestedStruct1& param1 = fcnArgs.at(0);
-        NestedStruct1 result = m_NestedStruct3Interface->func1(param1);
-        return result;
+        NestedStruct1 param1{};
+        argumentsReader.read(param1);
+        return ApiGear::ObjectLink::invokeReturnValue(m_NestedStruct3Interface->func1(param1));
     }
     if(memberMethod == "func2") {
-        const NestedStruct1& param1 = fcnArgs.at(0);
-        const NestedStruct2& param2 = fcnArgs.at(1);
-        NestedStruct1 result = m_NestedStruct3Interface->func2(param1, param2);
-        return result;
+        NestedStruct1 param1{};
+        argumentsReader.read(param1);
+        NestedStruct2 param2{};
+        argumentsReader.read(param2);
+        return ApiGear::ObjectLink::invokeReturnValue(m_NestedStruct3Interface->func2(param1, param2));
     }
     if(memberMethod == "func3") {
-        const NestedStruct1& param1 = fcnArgs.at(0);
-        const NestedStruct2& param2 = fcnArgs.at(1);
-        const NestedStruct3& param3 = fcnArgs.at(2);
-        NestedStruct1 result = m_NestedStruct3Interface->func3(param1, param2, param3);
-        return result;
+        NestedStruct1 param1{};
+        argumentsReader.read(param1);
+        NestedStruct2 param2{};
+        argumentsReader.read(param2);
+        NestedStruct3 param3{};
+        argumentsReader.read(param3);
+        return ApiGear::ObjectLink::invokeReturnValue(m_NestedStruct3Interface->func3(param1, param2, param3));
     }
-    return nlohmann::json();
+    return {};
 }
 
-void NestedStruct3InterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+void NestedStruct3InterfaceService::olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) {
     AG_LOG_DEBUG("NestedStruct3InterfaceService set property " + propertyId);
     const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
     if(memberProperty == "prop1") {
-        NestedStruct1 prop1 = value.get<NestedStruct1>();
-        m_NestedStruct3Interface->setProp1(prop1);
+        NestedStruct1 value_prop1{};
+        ApiGear::ObjectLink::readValue(value, value_prop1);
+        m_NestedStruct3Interface->setProp1(value_prop1);
     }
     if(memberProperty == "prop2") {
-        NestedStruct2 prop2 = value.get<NestedStruct2>();
-        m_NestedStruct3Interface->setProp2(prop2);
+        NestedStruct2 value_prop2{};
+        ApiGear::ObjectLink::readValue(value, value_prop2);
+        m_NestedStruct3Interface->setProp2(value_prop2);
     }
     if(memberProperty == "prop3") {
-        NestedStruct3 prop3 = value.get<NestedStruct3>();
-        m_NestedStruct3Interface->setProp3(prop3);
+        NestedStruct3 value_prop3{};
+        ApiGear::ObjectLink::readValue(value, value_prop3);
+        m_NestedStruct3Interface->setProp3(value_prop3);
     } 
 }
 
@@ -84,17 +92,16 @@ void NestedStruct3InterfaceService::olinkUnlinked(const std::string& objectId){
     AG_LOG_DEBUG("NestedStruct3InterfaceService unlinked " + objectId);
 }
 
-nlohmann::json NestedStruct3InterfaceService::olinkCollectProperties()
+ApiGear::ObjectLink::OLinkContent NestedStruct3InterfaceService::olinkCollectProperties()
 {
-    return nlohmann::json::object({
-        { "prop1", m_NestedStruct3Interface->getProp1() },
-        { "prop2", m_NestedStruct3Interface->getProp2() },
-        { "prop3", m_NestedStruct3Interface->getProp3() }
-    });
+    return ApiGear::ObjectLink::argumentsToContent(
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop1"), m_NestedStruct3Interface->getProp1()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop2"), m_NestedStruct3Interface->getProp2()),
+        ApiGear::ObjectLink::toInitialProperty(std::string("prop3"), m_NestedStruct3Interface->getProp3()) );
 }
 void NestedStruct3InterfaceService::onSig1(const NestedStruct1& param1)
 {
-    const nlohmann::json args = { param1 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig1");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -106,7 +113,7 @@ void NestedStruct3InterfaceService::onSig1(const NestedStruct1& param1)
 }
 void NestedStruct3InterfaceService::onSig2(const NestedStruct1& param1, const NestedStruct2& param2)
 {
-    const nlohmann::json args = { param1, param2 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1, param2);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig2");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -118,7 +125,7 @@ void NestedStruct3InterfaceService::onSig2(const NestedStruct1& param1, const Ne
 }
 void NestedStruct3InterfaceService::onSig3(const NestedStruct1& param1, const NestedStruct2& param2, const NestedStruct3& param3)
 {
-    const nlohmann::json args = { param1, param2, param3 };
+    auto args = ApiGear::ObjectLink::argumentsToContent(param1, param2, param3);
     static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sig3");
     static const auto objectId = olinkObjectName();
     for(auto node: m_registry.getNodes(objectId)) {
@@ -135,7 +142,7 @@ void NestedStruct3InterfaceService::onProp1Changed(const NestedStruct1& prop1)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop1);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop1));
         }
     }
 }
@@ -146,7 +153,7 @@ void NestedStruct3InterfaceService::onProp2Changed(const NestedStruct2& prop2)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop2);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop2));
         }
     }
 }
@@ -157,7 +164,7 @@ void NestedStruct3InterfaceService::onProp3Changed(const NestedStruct3& prop3)
     for(auto node: m_registry.getNodes(objectId)) {
         auto lockedNode = node.lock();
         if(lockedNode) {
-            lockedNode->notifyPropertyChange(propertyId, prop3);
+            lockedNode->notifyPropertyChange(propertyId, ApiGear::ObjectLink::propertyToContent(prop3));
         }
     }
 }

--- a/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceservice.h
+++ b/goldenmaster/modules/testbed2_module/testbed2/generated/olink/nestedstruct3interfaceservice.h
@@ -46,13 +46,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to NestedStruct3Interface object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -68,7 +68,7 @@ public:
     * Gets the current state of NestedStruct3Interface object.
     * @return the set of properties with their current values for the NestedStruct3Interface object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
     /**
     * Forwards emitted sig1 through network if the connection is established.
     */

--- a/templates/apigear/olink/CMakeLists.txt
+++ b/templates/apigear/olink/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT objectlink-core-cpp_FOUND)
   message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
   FetchContent_Declare(olink-core
       GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.6
+      GIT_TAG "dphan/extracting-protocol-format"
       GIT_SHALLOW TRUE
       EXCLUDE_FROM_ALL FALSE
   )

--- a/templates/apigear/olink/tests/olink_connection.test.cpp
+++ b/templates/apigear/olink/tests/olink_connection.test.cpp
@@ -64,6 +64,16 @@ namespace {
            != container.end();
     }
 
+    std::string propert1Name = "property1";
+    std::string propert2Name = "property2";
+    std::string propert3Name = "property3";
+    std::string stringValue1 = "someString1";
+    int someIntValue1 = 91;
+    bool boolFalse = false;
+
+    auto initProperties = ApiGear::ObjectLink::argumentsToContent(ApiGear::ObjectLink::toInitialProperty(propert1Name, stringValue1),
+        ApiGear::ObjectLink::toInitialProperty(propert2Name, someIntValue1),
+        ApiGear::ObjectLink::toInitialProperty(propert3Name, boolFalse));
 }
 
 TEST_CASE("OlinkConnection tests")
@@ -96,7 +106,6 @@ TEST_CASE("OlinkConnection tests")
         REQUIRE(msgs[0].flags == Poco::Net::WebSocket::FRAME_TEXT);
         
         // Send init message from server and check it is delivered and decoded
-        nlohmann::json initProperties = { {"property1", "some_string" }, { "property2",  9 }, { "property3", false } };
         REQUIRE_CALL(*sink1, olinkOnInit(sink1Id, initProperties, testOlinkConnection->node().get()));
         
         auto preparedInitMessage = converter.toString(ApiGear::ObjectLink::Protocol::initMessage(sink1Id, initProperties));
@@ -143,7 +152,6 @@ TEST_CASE("OlinkConnection tests")
         REQUIRE(registry.getNode(sink1Id).lock() == testOlinkConnection->node());
 
         // Send from server init message
-        nlohmann::json initProperties = { {"property1", "some_string" }, { "property2",  9 }, { "property3", false } };
         REQUIRE_CALL(*sink1, olinkOnInit(sink1Id, initProperties, testOlinkConnection->node().get()));
         auto preparedInitMessage = converter.toString(ApiGear::ObjectLink::Protocol::initMessage(sink1Id, initProperties));
         server.sendFrame(preparedInitMessage);
@@ -274,7 +282,6 @@ TEST_CASE("OlinkConnection tests")
         REQUIRE(msgs[0].flags == Poco::Net::WebSocket::FRAME_TEXT);
 
         // Send init message from server and check it is delivered and decoded
-        nlohmann::json initProperties = { {"property1", "some_string" }, { "property2",  9 }, { "property3", false } };
         REQUIRE_CALL(*sink1, olinkOnInit(sink1Id, initProperties, testOlinkConnection->node().get()));
 
         auto preparedInitMessage = converter.toString(ApiGear::ObjectLink::Protocol::initMessage(sink1Id, initProperties));

--- a/templates/apigear/olink/tests/olinkhost.test.cpp
+++ b/templates/apigear/olink/tests/olinkhost.test.cpp
@@ -53,8 +53,22 @@ namespace {
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/ws", Poco::Net::HTTPRequest::HTTP_1_1);
         Poco::Net::HTTPResponse response;
 
-        nlohmann::json initProperties1 = { {"property1", "some_string1" }, { "property2",  92 }, { "property3", true } };
-        nlohmann::json initProperties2 = { {"property1", "some_string2" }, { "property2",  29 }, { "property3", false } };
+        std::string propert1Name = "property1";
+        std::string propert2Name = "property2";
+        std::string propert3Name = "property3";
+        std::string stringValue1 = "someString1";
+        std::string stringValue2 = "someString2";
+        int someIntValue1 = 91;
+        int someIntValue2 = 19;
+        bool boolFalse = false;
+        bool boolTrue = true;
+
+        auto initProperties1 = ApiGear::ObjectLink::argumentsToContent(ApiGear::ObjectLink::toInitialProperty(propert1Name, stringValue1),
+            ApiGear::ObjectLink::toInitialProperty( propert2Name,  someIntValue1),
+            ApiGear::ObjectLink::toInitialProperty( propert3Name, boolTrue ));
+        auto initProperties2 = ApiGear::ObjectLink::argumentsToContent(ApiGear::ObjectLink::toInitialProperty(propert1Name, stringValue2),
+            ApiGear::ObjectLink::toInitialProperty( propert2Name,  someIntValue2),
+            ApiGear::ObjectLink::toInitialProperty( propert3Name, boolFalse));
 
         std::string any_payload = "any";
 

--- a/templates/module/generated/olink/interfaceclient.h.tpl
+++ b/templates/module/generated/olink/interfaceclient.h.tpl
@@ -93,21 +93,21 @@ public:
     * @param signalId Unique identifier for the signal emitted from object.
     * @param args The arguments for the signal.
     */
-    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    void olinkOnSignal(const std::string& signalId, const ApiGear::ObjectLink::OLinkContent& args) override;
     
     /**
     * Applies the information about the property changed on server side.
     * @param propertyId Unique identifier of a changed property in object .
     * @param value The value of the property.
     */
-    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkOnPropertyChanged(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     
     /** Informs this object sink that connection was is established.
     * @param interfaceId The name of the object for which link was established.
     * @param props Initial values obtained from the {{$interfaceNameOriginal}} service
     * @param the initialized link endpoint for this sink.
     */
-    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    void olinkOnInit(const std::string& interfaceId, const ApiGear::ObjectLink::OLinkContent& props, ApiGear::ObjectLink::IClientNode *node) override;
     /**
     * Informs this object source that the link was disconnected and cannot be used anymore.
     */
@@ -115,16 +115,11 @@ public:
 
 private:
     /**
-    * Applies received data to local state and publishes changes to subscribers.
-    * @param the data received from {{$interfaceNameOriginal}} service.
-    */
-    void applyState(const nlohmann::json& fields);
-    /**
     * Applies received property value to local state and publishes changes to subscribers.
     * @param propertyName the name of property to be changed.
     * @param value The value for property.
     */
-    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    void applyProperty(const std::string& propertyName, const ApiGear::ObjectLink::OLinkContent& value);
 {{- range .Interface.Properties}}
 {{- $property := . }}
     /**  Updates local value for {{Camel $property.Name}} and informs subscriber about the change*/

--- a/templates/module/generated/olink/interfaceservice.h.tpl
+++ b/templates/module/generated/olink/interfaceservice.h.tpl
@@ -49,13 +49,13 @@ public:
     * @param args Arguments required to invoke a method in json format.
     * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
     */
-    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    ApiGear::ObjectLink::OLinkContent olinkInvoke(const std::string& methodId, const ApiGear::ObjectLink::OLinkContent& args) override;
     /**
     * Applies received change property request to {{$interfaceNameOriginal}} object.
     * @param name Path the property to change. Contains object name and the property name.
     * @param args Value in json format requested to set for the property.
     */
-    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    void olinkSetProperty(const std::string& propertyId, const ApiGear::ObjectLink::OLinkContent& value) override;
     /**
     * Informs this service source that the link was established.
     * @param name The name of the object for which link was established.
@@ -71,7 +71,7 @@ public:
     * Gets the current state of {{$interfaceNameOriginal}} object.
     * @return the set of properties with their current values for the {{$interfaceNameOriginal}} object in json format.
     */
-    nlohmann::json olinkCollectProperties() override;
+    ApiGear::ObjectLink::OLinkContent olinkCollectProperties() override;
 
 {{- range .Interface.Signals}}
 {{- $signal := . }}


### PR DESCRIPTION
Branch should align to https://github.com/apigear-io/objectlink-core-cpp/pull/42 - a protocol change
for now it is aligned only to first commit in there. 
Uses the new structure in interface - not a nlohmann::json, but OLinkContent

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->