### PR TITLE
Feature/support for read only properties

### DIFF
--- a/apigear/testbed.simple.module.yaml
+++ b/apigear/testbed.simple.module.yaml
@@ -99,6 +99,7 @@ interfaces:
       - { name: propFloat32, type: float32, array: true  }
       - { name: propFloat64, type: float64, array: true  }
       - { name: propString, type: string, array: true }
+      - { name: propReadOnlyString, type: string, readonly: true }
     operations:
       - name: funcBool
         params:

--- a/goldenmaster/examples/appthreadsafe/main.cpp
+++ b/goldenmaster/examples/appthreadsafe/main.cpp
@@ -312,6 +312,8 @@ void testTbSimpleSimpleArrayInterface()
     auto l_propString = std::list<std::string>();
     l_propString = testSimpleArrayInterface->getPropString();
     testSimpleArrayInterface->setPropString(l_propString);
+    auto l_propReadOnlyString = std::string();
+    l_propReadOnlyString = testSimpleArrayInterface->getPropReadOnlyString();
 }
 
 void testTbSimpleNoPropertiesInterface()

--- a/goldenmaster/modules/tb_simple/generated/api/simplearrayinterface.api.h
+++ b/goldenmaster/modules/tb_simple/generated/api/simplearrayinterface.api.h
@@ -163,6 +163,11 @@ public:
     virtual const std::list<std::string>& getPropString() const = 0;
 
     /**
+    * Gets the value of the propReadOnlyString property.
+    */
+    virtual const std::string& getPropReadOnlyString() const = 0;
+
+    /**
     * Access to a publisher, use it to subscribe for SimpleArrayInterface changes and signal emission.
     * This function name doesn't follow the convention, because it is added to user defined interface,
     * to avoid potentially name clashes, it has the trailing underscore in the name.
@@ -287,6 +292,12 @@ public:
     * @warning the subscribed function shall not be blocking and must return immediately!
     */
     virtual void onPropStringChanged(const std::list<std::string>& propString) = 0;
+    /**
+    * Called by the ISimpleArrayInterfacePublisher when propReadOnlyString value has changed if subscribed for the propReadOnlyString change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropReadOnlyStringChanged(const std::string& propReadOnlyString) = 0;
 };
 
 /** Callback for changes of propBool */
@@ -305,6 +316,8 @@ using SimpleArrayInterfacePropFloat32PropertyCb = std::function<void(const std::
 using SimpleArrayInterfacePropFloat64PropertyCb = std::function<void(const std::list<double>& propFloat64)>;
 /** Callback for changes of propString */
 using SimpleArrayInterfacePropStringPropertyCb = std::function<void(const std::list<std::string>& propString)>;
+/** Callback for changes of propReadOnlyString */
+using SimpleArrayInterfacePropReadOnlyStringPropertyCb = std::function<void(const std::string& propReadOnlyString)>;
 /** Callback for sigBool signal triggers */
 using SimpleArrayInterfaceSigBoolSignalCb = std::function<void(const std::list<bool>& paramBool)> ;
 /** Callback for sigInt signal triggers */
@@ -499,6 +512,24 @@ public:
     virtual void unsubscribeFromPropStringChanged(long handleId) = 0;
 
     /**
+    * Use this function to subscribe for propReadOnlyString value changes.
+    * If your subscriber uses subscription with ISimpleArrayInterfaceSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param SimpleArrayInterfacePropReadOnlyStringPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual long subscribeToPropReadOnlyStringChanged(SimpleArrayInterfacePropReadOnlyStringPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propReadOnlyString property changes.
+    * If your subscriber uses subscription with ISimpleArrayInterfaceSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropReadOnlyStringChanged(long handleId) = 0;
+
+    /**
     * Use this function to subscribe for sigBool signal changes.
     * @param SimpleArrayInterfaceSigBoolSignalCb callback that will be executed on each signal emission.
     * Make sure to remove subscription before the callback becomes invalid.
@@ -666,6 +697,12 @@ public:
     * @param The new value of propString.
     */
     virtual void publishPropStringChanged(const std::list<std::string>& propString) const = 0;
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the SimpleArrayInterface implementation when property propReadOnlyString changes.
+    * @param The new value of propReadOnlyString.
+    */
+    virtual void publishPropReadOnlyStringChanged(const std::string& propReadOnlyString) const = 0;
     /**
     * Publishes the emitted signal to all subscribed clients.
     * Needs to be invoked by the SimpleArrayInterface implementation when sigBool is emitted.

--- a/goldenmaster/modules/tb_simple/generated/core/simplearrayinterface.data.h
+++ b/goldenmaster/modules/tb_simple/generated/core/simplearrayinterface.data.h
@@ -21,6 +21,7 @@ struct SimpleArrayInterfaceData
     std::list<float> m_propFloat32 {std::list<float>()};
     std::list<double> m_propFloat64 {std::list<double>()};
     std::list<std::string> m_propString {std::list<std::string>()};
+    std::string m_propReadOnlyString {std::string()};
 };
 
 }

--- a/goldenmaster/modules/tb_simple/generated/core/simplearrayinterface.publisher.h
+++ b/goldenmaster/modules/tb_simple/generated/core/simplearrayinterface.publisher.h
@@ -105,6 +105,15 @@ public:
     void unsubscribeFromPropStringChanged(long handleId) override;
 
     /**
+    * Implementation of ISimpleArrayInterfacePublisher::subscribeToPropReadOnlyStringChanged
+    */
+    long subscribeToPropReadOnlyStringChanged(SimpleArrayInterfacePropReadOnlyStringPropertyCb callback) override;
+    /**
+    * Implementation of ISimpleArrayInterfacePublisher::subscribeToPropReadOnlyStringChanged
+    */
+    void unsubscribeFromPropReadOnlyStringChanged(long handleId) override;
+
+    /**
     * Implementation of ISimpleArrayInterfacePublisher::subscribeToSigBool
     */
     long subscribeToSigBool(SimpleArrayInterfaceSigBoolSignalCb callback) override;
@@ -209,6 +218,10 @@ public:
     */
     void publishPropStringChanged(const std::list<std::string>& propString) const override;
     /**
+    * Implementation of ISimpleArrayInterfacePublisher::publishPropReadOnlyStringChanged
+    */
+    void publishPropReadOnlyStringChanged(const std::string& propReadOnlyString) const override;
+    /**
     * Implementation of ISimpleArrayInterfacePublisher::publishSigBool
     */
     void publishSigBool(const std::list<bool>& paramBool) const override;
@@ -293,6 +306,12 @@ private:
     std::map<long, SimpleArrayInterfacePropStringPropertyCb> m_propStringCallbacks;
     // Mutex for m_propStringCallbacks
     mutable std::shared_timed_mutex m_propStringCallbacksMutex;
+    // Next free unique identifier to subscribe for the PropReadOnlyString change.
+    std::atomic<long> m_propReadOnlyStringChangedCallbackNextId {0};
+    // Subscribed callbacks for the PropReadOnlyString change.
+    std::map<long, SimpleArrayInterfacePropReadOnlyStringPropertyCb> m_propReadOnlyStringCallbacks;
+    // Mutex for m_propReadOnlyStringCallbacks
+    mutable std::shared_timed_mutex m_propReadOnlyStringCallbacksMutex;
     // Next free unique identifier to subscribe for the SigBool emission.
     std::atomic<long> m_sigBoolSignalCallbackNextId {0};
     // Subscribed callbacks for the SigBool emission.

--- a/goldenmaster/modules/tb_simple/generated/core/simplearrayinterface.threadsafedecorator.cpp
+++ b/goldenmaster/modules/tb_simple/generated/core/simplearrayinterface.threadsafedecorator.cpp
@@ -168,6 +168,12 @@ const std::list<std::string>& SimpleArrayInterfaceThreadSafeDecorator::getPropSt
     return m_impl->getPropString();
 }
 
+const std::string& SimpleArrayInterfaceThreadSafeDecorator::getPropReadOnlyString() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propReadOnlyStringMutex);
+    return m_impl->getPropReadOnlyString();
+}
+
 ISimpleArrayInterfacePublisher& SimpleArrayInterfaceThreadSafeDecorator::_getPublisher() const
 {
     return m_impl->_getPublisher();

--- a/goldenmaster/modules/tb_simple/generated/core/simplearrayinterface.threadsafedecorator.h
+++ b/goldenmaster/modules/tb_simple/generated/core/simplearrayinterface.threadsafedecorator.h
@@ -41,6 +41,7 @@ auto propFloat64 = testSimpleArrayInterface->getPropFloat64();
 testSimpleArrayInterface->setPropFloat64(std::list<double>());
 auto propString = testSimpleArrayInterface->getPropString();
 testSimpleArrayInterface->setPropString(std::list<std::string>());
+auto propReadOnlyString = testSimpleArrayInterface->getPropReadOnlyString();
 \endcode
 */
 class TEST_TB_SIMPLE_EXPORT SimpleArrayInterfaceThreadSafeDecorator : public ISimpleArrayInterface
@@ -180,6 +181,9 @@ public:
     /** Guards and forwards call to SimpleArrayInterface implementation. */
     const std::list<std::string>& getPropString() const override;
 
+    /** Guards and forwards call to SimpleArrayInterface implementation. */
+    const std::string& getPropReadOnlyString() const override;
+
     /**
     * Access to a publisher, use it to subscribe for SimpleArrayInterface changes and signal emission.
     * This call is thread safe.
@@ -205,6 +209,8 @@ private:
     mutable std::shared_timed_mutex m_propFloat64Mutex;
     // Mutex for propString property
     mutable std::shared_timed_mutex m_propStringMutex;
+    // Mutex for propReadOnlyString property
+    mutable std::shared_timed_mutex m_propReadOnlyStringMutex;
 };
 } // namespace TbSimple
 } // namespace Test

--- a/goldenmaster/modules/tb_simple/generated/monitor/simplearrayinterface.tracedecorator.cpp
+++ b/goldenmaster/modules/tb_simple/generated/monitor/simplearrayinterface.tracedecorator.cpp
@@ -171,6 +171,11 @@ const std::list<std::string>& SimpleArrayInterfaceTraceDecorator::getPropString(
 {
     return m_impl.getPropString();
 }
+
+const std::string& SimpleArrayInterfaceTraceDecorator::getPropReadOnlyString() const
+{
+    return m_impl.getPropReadOnlyString();
+}
 void SimpleArrayInterfaceTraceDecorator::onSigBool(const std::list<bool>& paramBool)
 {
     m_tracer->trace_sigBool(paramBool);
@@ -256,6 +261,12 @@ void SimpleArrayInterfaceTraceDecorator::onPropFloat64Changed(const std::list<do
 void SimpleArrayInterfaceTraceDecorator::onPropStringChanged(const std::list<std::string>& propString)
 {
     (void) propString; // suppress the 'Unreferenced Formal Parameter' warning.
+    m_tracer->capture_state(this);
+}
+
+void SimpleArrayInterfaceTraceDecorator::onPropReadOnlyStringChanged(const std::string& propReadOnlyString)
+{
+    (void) propReadOnlyString; // suppress the 'Unreferenced Formal Parameter' warning.
     m_tracer->capture_state(this);
 }
 

--- a/goldenmaster/modules/tb_simple/generated/monitor/simplearrayinterface.tracedecorator.h
+++ b/goldenmaster/modules/tb_simple/generated/monitor/simplearrayinterface.tracedecorator.h
@@ -114,6 +114,9 @@ public:
     /** Forwards call to SimpleArrayInterface implementation. */
     const std::list<std::string>& getPropString() const override;
     
+    /** Forwards call to SimpleArrayInterface implementation. */
+    const std::string& getPropReadOnlyString() const override;
+    
     /**
     Traces sigBool emission.
     */
@@ -178,6 +181,10 @@ public:
     Traces propString changed.
     */
     void onPropStringChanged(const std::list<std::string>& propString) override;
+    /**
+    Traces propReadOnlyString changed.
+    */
+    void onPropReadOnlyStringChanged(const std::string& propReadOnlyString) override;
 
     /**
     * Access to a publisher, use it to subscribe for SimpleArrayInterface changes and signal emission.

--- a/goldenmaster/modules/tb_simple/generated/monitor/simplearrayinterface.tracer.cpp
+++ b/goldenmaster/modules/tb_simple/generated/monitor/simplearrayinterface.tracer.cpp
@@ -20,6 +20,7 @@ void SimpleArrayInterfaceTracer::capture_state(ISimpleArrayInterface* obj)
     fields_["propFloat32"] = obj->getPropFloat32();
     fields_["propFloat64"] = obj->getPropFloat64();
     fields_["propString"] = obj->getPropString();
+    fields_["propReadOnlyString"] = obj->getPropReadOnlyString();
     m_tracer.state("tb.simple.SimpleArrayInterface#_state", fields_);
 }
 

--- a/goldenmaster/modules/tb_simple/generated/mqtt/simplearrayinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple/generated/mqtt/simplearrayinterfaceclient.cpp
@@ -304,6 +304,11 @@ const std::list<std::string>& SimpleArrayInterfaceClient::getPropString() const
     return m_data.m_propString;
 }
 
+const std::string& SimpleArrayInterfaceClient::getPropReadOnlyString() const
+{
+    return m_data.m_propReadOnlyString;
+}
+
 std::list<bool> SimpleArrayInterfaceClient::funcBool(const std::list<bool>& paramBool)
 {
     if(m_client == nullptr) {

--- a/goldenmaster/modules/tb_simple/generated/mqtt/simplearrayinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple/generated/mqtt/simplearrayinterfaceclient.h
@@ -30,6 +30,7 @@ public:
     void setPropFloat64(const std::list<double>& propFloat64) override;
     const std::list<std::string>& getPropString() const override;
     void setPropString(const std::list<std::string>& propString) override;
+    const std::string& getPropReadOnlyString() const override;
     std::list<bool> funcBool(const std::list<bool>& paramBool) override;
     std::future<std::list<bool>> funcBoolAsync(const std::list<bool>& paramBool) override;
     std::list<int> funcInt(const std::list<int>& paramInt) override;

--- a/goldenmaster/modules/tb_simple/generated/mqtt/simplearrayinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple/generated/mqtt/simplearrayinterfaceservice.cpp
@@ -70,6 +70,7 @@ void SimpleArrayInterfaceService::onConnectionStatusChanged(bool connectionStatu
     onPropFloat32Changed(m_impl->getPropFloat32());
     onPropFloat64Changed(m_impl->getPropFloat64());
     onPropStringChanged(m_impl->getPropString());
+    onPropReadOnlyStringChanged(m_impl->getPropReadOnlyString());
 }
 void SimpleArrayInterfaceService::onSetPropBool(const std::string& args) const
 {
@@ -333,5 +334,12 @@ void SimpleArrayInterfaceService::onPropStringChanged(const std::list<std::strin
     if(m_service != nullptr) {
         static const auto topic = std::string("tb.simple/SimpleArrayInterface/prop/propString");
         m_service->notifyPropertyChange(topic, nlohmann::json(propString).dump());
+    }
+}
+void SimpleArrayInterfaceService::onPropReadOnlyStringChanged(const std::string& propReadOnlyString)
+{
+    if(m_service != nullptr) {
+        static const auto topic = std::string("tb.simple/SimpleArrayInterface/prop/propReadOnlyString");
+        m_service->notifyPropertyChange(topic, nlohmann::json(propReadOnlyString).dump());
     }
 }

--- a/goldenmaster/modules/tb_simple/generated/mqtt/simplearrayinterfaceservice.h
+++ b/goldenmaster/modules/tb_simple/generated/mqtt/simplearrayinterfaceservice.h
@@ -69,6 +69,7 @@ private:
     /// @brief requests to set the value for the property PropString coming from the client
     /// @param fields contains the param of the type std::list<std::string>
     void onSetPropString(const std::string& args) const;
+    void onPropReadOnlyStringChanged(const std::string& propReadOnlyString) override;
 
     std::shared_ptr<ISimpleArrayInterface> m_impl;
     std::shared_ptr<ApiGear::MQTT::Service> m_service;

--- a/goldenmaster/modules/tb_simple/generated/olink/simplearrayinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple/generated/olink/simplearrayinterfaceclient.cpp
@@ -307,6 +307,12 @@ const std::list<std::string>& SimpleArrayInterfaceClient::getPropString() const
     return m_data.m_propString;
 }
 
+const std::string& SimpleArrayInterfaceClient::getPropReadOnlyString() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propReadOnlyStringMutex);
+    return m_data.m_propReadOnlyString;
+}
+
 std::list<bool> SimpleArrayInterfaceClient::funcBool(const std::list<bool>& paramBool)
 {
     return funcBoolAsync(paramBool).get();

--- a/goldenmaster/modules/tb_simple/generated/olink/simplearrayinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple/generated/olink/simplearrayinterfaceclient.h
@@ -121,6 +121,11 @@ public:
     */
     void setPropString(const std::list<std::string>& propString) override;
     /**
+    * Property getter
+    * @return Locally stored locally value for PropReadOnlyString.
+    */
+    const std::string& getPropReadOnlyString() const override;
+    /**
     * Remote call of ISimpleArrayInterface::funcBool on the SimpleArrayInterface service.
     * Uses funcBoolAsync
     */
@@ -278,6 +283,10 @@ private:
     void setPropStringLocal(const std::list<std::string>& propString);
     /* Mutex for propString property */
     mutable std::shared_timed_mutex m_propStringMutex;
+    /**  Updates local value for PropReadOnlyString and informs subscriber about the change*/
+    void setPropReadOnlyStringLocal(const std::string& propReadOnlyString);
+    /* Mutex for propReadOnlyString property */
+    mutable std::shared_timed_mutex m_propReadOnlyStringMutex;
 
     /** Local storage for properties values. */
     SimpleArrayInterfaceData m_data;

--- a/goldenmaster/modules/tb_simple/generated/olink/simplearrayinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple/generated/olink/simplearrayinterfaceservice.cpp
@@ -136,7 +136,8 @@ nlohmann::json SimpleArrayInterfaceService::olinkCollectProperties()
         { "propFloat", m_SimpleArrayInterface->getPropFloat() },
         { "propFloat32", m_SimpleArrayInterface->getPropFloat32() },
         { "propFloat64", m_SimpleArrayInterface->getPropFloat64() },
-        { "propString", m_SimpleArrayInterface->getPropString() }
+        { "propString", m_SimpleArrayInterface->getPropString() },
+        { "propReadOnlyString", m_SimpleArrayInterface->getPropReadOnlyString() }
     });
 }
 void SimpleArrayInterfaceService::onSigBool(const std::list<bool>& paramBool)
@@ -320,6 +321,17 @@ void SimpleArrayInterfaceService::onPropStringChanged(const std::list<std::strin
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propString);
+        }
+    }
+}
+void SimpleArrayInterfaceService::onPropReadOnlyStringChanged(const std::string& propReadOnlyString)
+{
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propReadOnlyString");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propReadOnlyString);
         }
     }
 }

--- a/goldenmaster/modules/tb_simple/generated/olink/simplearrayinterfaceservice.h
+++ b/goldenmaster/modules/tb_simple/generated/olink/simplearrayinterfaceservice.h
@@ -133,6 +133,10 @@ public:
     * Forwards propString change through network if the connection is established.
     */
     void onPropStringChanged(const std::list<std::string>& propString) override;
+    /**
+    * Forwards propReadOnlyString change through network if the connection is established.
+    */
+    void onPropReadOnlyStringChanged(const std::string& propReadOnlyString) override;
 
 private:
     /**

--- a/goldenmaster/modules/tb_simple/implementation/simplearrayinterface.cpp
+++ b/goldenmaster/modules/tb_simple/implementation/simplearrayinterface.cpp
@@ -118,6 +118,19 @@ const std::list<std::string>& SimpleArrayInterface::getPropString() const
     return m_data.m_propString;
 }
 
+void SimpleArrayInterface::setPropReadOnlyString(const std::string& propReadOnlyString)
+{
+    if (m_data.m_propReadOnlyString != propReadOnlyString) {
+        m_data.m_propReadOnlyString = propReadOnlyString;
+        m_publisher->publishPropReadOnlyStringChanged(propReadOnlyString);
+    }
+}
+
+const std::string& SimpleArrayInterface::getPropReadOnlyString() const
+{
+    return m_data.m_propReadOnlyString;
+}
+
 std::list<bool> SimpleArrayInterface::funcBool(const std::list<bool>& paramBool)
 {
     (void) paramBool; // suppress the 'Unreferenced Formal Parameter' warning.

--- a/goldenmaster/modules/tb_simple/implementation/simplearrayinterface.h
+++ b/goldenmaster/modules/tb_simple/implementation/simplearrayinterface.h
@@ -41,6 +41,9 @@ public:
     void setPropString(const std::list<std::string>& propString) override;
     const std::list<std::string>& getPropString() const override;
     
+    void setPropReadOnlyString(const std::string& propReadOnlyString);
+    const std::string& getPropReadOnlyString() const override;
+    
     std::list<bool> funcBool(const std::list<bool>& paramBool) override;
     std::future<std::list<bool>> funcBoolAsync(const std::list<bool>& paramBool) override;
         

--- a/goldenmaster/modules/tb_simple/implementation/simplearrayinterface.test.cpp
+++ b/goldenmaster/modules/tb_simple/implementation/simplearrayinterface.test.cpp
@@ -78,4 +78,8 @@ TEST_CASE("Testing SimpleArrayInterface", "[SimpleArrayInterface]"){
         testSimpleArrayInterface->setPropString(std::list<std::string>());
         REQUIRE( testSimpleArrayInterface->getPropString() == std::list<std::string>() );
     }
+    SECTION("Test property propReadOnlyString") {
+        // Do implement test here
+        REQUIRE( testSimpleArrayInterface->getPropReadOnlyString() == std::string() );
+    }
 }

--- a/templates/examples/appthreadsafe/main.cpp.tpl
+++ b/templates/examples/appthreadsafe/main.cpp.tpl
@@ -24,7 +24,9 @@ void test{{ Camel $module.Name }}{{$class}}()
 {{- $property := . }}
     auto l_{{lower1 (Camel $property.Name)}} = {{cppDefault "" $property}};
     l_{{lower1 (Camel $property.Name)}} = test{{$class}}->get{{Camel $property.Name}}();
+{{- if not .IsReadOnly }}
     test{{$class}}->set{{Camel $property.Name}}(l_{{lower1 (Camel $property.Name)}});
+{{- end }}
 {{- end }}
 }{{nl}}
 {{- end }}

--- a/templates/module/generated/api/interface.api.h.tpl
+++ b/templates/module/generated/api/interface.api.h.tpl
@@ -68,6 +68,7 @@ public:
 
 {{- range .Interface.Properties }}
 {{- $property := . }}
+{{- if not .IsReadOnly }}
     /**
     * Sets the value of the {{$property.Name}} property.
     {{- if $property.Description }}
@@ -75,6 +76,7 @@ public:
     {{- end }}    {{- /* end if property.Description */}}
     */
     virtual void set{{Camel $property.Name}}({{ cppParam "" $property }}) = 0;
+{{- end }}
     /**
     * Gets the value of the {{$property.Name}} property.
     {{- if $property.Description }}

--- a/templates/module/generated/core/interface.threadsafedecorator.cpp.tpl
+++ b/templates/module/generated/core/interface.threadsafedecorator.cpp.tpl
@@ -30,11 +30,13 @@ std::future<{{cppReturn "" $operation.Return}}> {{$class}}::{{lower1 $operation.
 
 {{- range .Interface.Properties}}
 {{- $property := . }}
+{{- if not .IsReadOnly }}
 void {{$class}}::set{{Camel $property.Name}}({{cppParam "" $property}})
 {
     std::unique_lock<std::shared_timed_mutex> lock(m_{{lower1 ((Camel $property.Name))}}Mutex);
     m_impl->set{{Camel $property.Name}}({{$property.Name}});
 }
+{{- end }}
 
 {{cppTypeRef "" $property}} {{$class}}::get{{Camel $property.Name}}() const
 {

--- a/templates/module/generated/core/interface.threadsafedecorator.h.tpl
+++ b/templates/module/generated/core/interface.threadsafedecorator.h.tpl
@@ -34,7 +34,9 @@ std::unique_ptr<{{$interfaceClass}}> test{{$interfaceName}} = std::make_unique<{
 {{- range .Interface.Properties}}
 {{- $property := . }}
 auto {{lower1 (Camel $property.Name)}} = test{{$interfaceName}}->get{{Camel $property.Name}}();
+{{- if not .IsReadOnly }}
 test{{$interfaceName}}->set{{Camel $property.Name}}({{cppDefault "" $property}});
+{{- end }}
 {{- end }}
 \endcode
 */
@@ -62,8 +64,10 @@ public:
 {{- end }}
 {{- range .Interface.Properties}}
 {{- $property := . }}
+{{- if not .IsReadOnly }}
     /** Guards and forwards call to {{$interfaceNameOriginal}} implementation. */
     void set{{Camel $property.Name}}({{cppParam  "" $property }}) override;
+{{- end }}
     /** Guards and forwards call to {{$interfaceNameOriginal}} implementation. */
     {{cppTypeRef "" $property}} get{{Camel $property.Name}}() const override;
 {{- nl }}

--- a/templates/module/generated/monitor/interface.tracedecorator.cpp.tpl
+++ b/templates/module/generated/monitor/interface.tracedecorator.cpp.tpl
@@ -43,10 +43,12 @@ std::future<{{cppReturn "" $operation.Return}}> {{$class}}::{{lower1 $operation.
 
 {{- range .Interface.Properties}}
 {{- $property := . }}
+{{- if not .IsReadOnly }}
 void {{$class}}::set{{Camel $property.Name}}({{cppParam "" $property}})
 {
     m_impl.set{{Camel $property.Name}}({{$property.Name}});
 }
+{{- end }}
 
 {{cppTypeRef "" $property}} {{$class}}::get{{Camel $property.Name}}() const
 {

--- a/templates/module/generated/monitor/interface.tracedecorator.h.tpl
+++ b/templates/module/generated/monitor/interface.tracedecorator.h.tpl
@@ -50,8 +50,10 @@ public:
     {{ end -}}
 {{- range .Interface.Properties}}
 {{- $property := . }}
+{{- if not .IsReadOnly }}
     /** Forwards call to {{$interfaceNameOriginal}} implementation. */
     void set{{Camel $property.Name}}({{cppParam  "" $property }}) override;
+{{- end }}
     /** Forwards call to {{$interfaceNameOriginal}} implementation. */
     {{cppTypeRef "" $property}} get{{Camel $property.Name}}() const override;
     {{ end -}}

--- a/templates/module/generated/mqtt/mqttclient.cpp.tpl
+++ b/templates/module/generated/mqtt/mqttclient.cpp.tpl
@@ -39,7 +39,9 @@ std::map<std::string, ApiGear::MQTT::CallbackFunction> {{$class}}::createTopicMa
     return {
     {{- range .Interface.Properties}}
     {{- $property := . }}
+    {{- if not .IsReadOnly }}
         { std::string("{{$.Module.Name}}/{{$interfaceName}}/prop/{{$property}}"), [this](const std::string& args, const std::string&, const std::string&){ this->set{{Camel $property.Name}}Local(args); } },
+    {{- end }}
     {{- end }}
     {{- range .Interface.Signals}}
     {{- $signal := . }}
@@ -69,6 +71,7 @@ void {{$class}}::onConnectionStatusChanged(bool connectionStatus)
 {{- range .Interface.Properties}}
 {{- $property := . }}
 {{- $name := $property.Name }}
+{{- if not .IsReadOnly }}
 
 void {{$class}}::set{{Camel $name}}({{cppParam "" $property}})
 {
@@ -93,6 +96,7 @@ void {{$class}}::set{{Camel $name}}Local(const std::string& args)
         m_publisher->publish{{Camel $name}}Changed({{$name}});
     }
 }
+{{- end }}
 
 {{cppTypeRef "" $property}} {{$class}}::get{{Camel $name}}() const
 {

--- a/templates/module/generated/mqtt/mqttclient.h.tpl
+++ b/templates/module/generated/mqtt/mqttclient.h.tpl
@@ -25,7 +25,9 @@ public:
 {{- range .Interface.Properties}}
 {{- $property := . }}
     {{cppTypeRef "" $property}} get{{Camel $property.Name}}() const override;
+{{- if not .IsReadOnly }}
     void set{{Camel $property.Name}}({{cppParam "" $property}}) override;
+{{- end }}
 {{- end }}
 
 {{- range .Interface.Operations}}
@@ -48,9 +50,11 @@ private:
 
 {{- range .Interface.Properties}}
 {{- $property := . }}
+{{- if not .IsReadOnly }}
     /// @brief sets the value for the property {{Camel $property.Name}} coming from the service
     /// @param args contains the param of the type {{cppType "" $property }}
     void set{{Camel $property.Name}}Local(const std::string& args);
+{{- end }}
 {{- end }}
 
 {{- range .Interface.Signals}}

--- a/templates/module/generated/mqtt/mqttservice.cpp.tpl
+++ b/templates/module/generated/mqtt/mqttservice.cpp.tpl
@@ -37,7 +37,9 @@ std::map<std::string, ApiGear::MQTT::CallbackFunction> {{$class}}::createTopicMa
     return {
     {{- range .Interface.Properties}}
     {{- $property := . }}
+    {{- if not .IsReadOnly }}
         {std::string("{{$.Module.Name}}/{{$interface}}/set/{{$property}}"), [this](const std::string& args, const std::string&, const std::string&){ this->onSet{{Camel $property.Name}}(args); } },
+    {{- end }}
     {{- end }}
     {{- range .Interface.Operations}}
     {{- $operation := . }}
@@ -67,6 +69,7 @@ void {{$class}}::onConnectionStatusChanged(bool connectionStatus)
 
 {{- range .Interface.Properties}}
 {{- $property := . }}
+{{- if not .IsReadOnly }}
 void {{$class}}::onSet{{Camel $property.Name}}(const std::string& args) const
 {
     nlohmann::json json_args = nlohmann::json::parse(args);
@@ -78,6 +81,7 @@ void {{$class}}::onSet{{Camel $property.Name}}(const std::string& args) const
     auto {{$property}} = json_args.get<{{cppType "" $property}}>();
     m_impl->set{{Camel $property.Name}}({{$property}});
 }
+{{- end }}
 {{- end }}
 
 {{- range .Interface.Operations}}

--- a/templates/module/generated/mqtt/mqttservice.h.tpl
+++ b/templates/module/generated/mqtt/mqttservice.h.tpl
@@ -41,9 +41,11 @@ private:
 {{- range .Interface.Properties}}
 {{- $property := . }}
     void on{{Camel $property.Name}}Changed({{cppParam "" $property}}) override;
+{{- if not .IsReadOnly }}
     /// @brief requests to set the value for the property {{Camel $property.Name}} coming from the client
     /// @param fields contains the param of the type {{cppType "" $property }}
     void onSet{{Camel $property.Name}}(const std::string& args) const;
+{{- end }}
 {{- end }}
 
     std::shared_ptr<{{$interfaceClass}}> m_impl;

--- a/templates/module/generated/olink/interfaceclient.cpp.tpl
+++ b/templates/module/generated/olink/interfaceclient.cpp.tpl
@@ -31,9 +31,11 @@ void {{$class}}::applyState(const nlohmann::json& fields)
 {
 {{- range .Interface.Properties}}
 {{- $property := . }}
+{{- if not .IsReadOnly }}
     if(fields.contains("{{$property.Name}}")) {
         set{{Camel $property.Name}}Local(fields["{{$property.Name}}"].get<{{cppType "" $property}}>());
     }
+{{- end }}
 {{- else }}
     // no properties to apply state {{- /* we generate anyway for consistency */}}
     (void) fields;
@@ -43,9 +45,11 @@ void {{$class}}::applyState(const nlohmann::json& fields)
 void {{$class}}::applyProperty(const std::string& propertyName, const nlohmann::json& value)
 {
 {{- range $idx, $property := .Interface.Properties }}
+{{- if not .IsReadOnly }}
     {{ if $idx }}else {{ end -}}if ( propertyName == "{{$property.Name}}") {
         set{{Camel $property.Name}}Local(value.get<{{cppType "" $property}}>());
     }
+{{- end }}
 {{- else -}}
     // no properties to apply state {{- /* we generate anyway for consistency */}}
     (void) propertyName;
@@ -56,6 +60,7 @@ void {{$class}}::applyProperty(const std::string& propertyName, const nlohmann::
 {{- range .Interface.Properties}}
 {{- $property := . }}
 {{- $name := $property.Name }}
+{{- if not .IsReadOnly }}
 
 void {{$class}}::set{{Camel $name}}({{cppParam "" $property}})
 {
@@ -79,6 +84,7 @@ void {{$class}}::set{{Camel $name}}Local({{cppParam "" $property }})
 
     m_publisher->publish{{Camel $name}}Changed({{$name}});
 }
+{{- end }}
 
 {{cppTypeRef "" $property}} {{$class}}::get{{Camel $name}}() const
 {

--- a/templates/module/generated/olink/interfaceclient.h.tpl
+++ b/templates/module/generated/olink/interfaceclient.h.tpl
@@ -56,11 +56,13 @@ public:
     * @return Locally stored locally value for {{Camel $property.Name}}.
     */
     {{cppTypeRef "" $property}} get{{Camel $property.Name}}() const override;
+{{- if not .IsReadOnly }}
     /**
     * Request setting a property on the {{$interfaceNameOriginal}} service.
     * @param The value to which set request is send for the {{Camel $property.Name}}.
     */
     void set{{Camel $property.Name}}({{cppParam "" $property}}) override;
+{{- end }}
 {{- end }}
 {{- range .Interface.Operations}}
 {{- $operation := . }}

--- a/templates/module/generated/olink/interfaceservice.cpp.tpl
+++ b/templates/module/generated/olink/interfaceservice.cpp.tpl
@@ -81,10 +81,12 @@ void {{$class}}::olinkSetProperty(const std::string& propertyId, const nlohmann:
     const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
 {{- range .Interface.Properties}}
 {{- $property := . }}
+{{- if not .IsReadOnly }}
     if(memberProperty == "{{$property}}") {
         {{cppType "" $property}} {{$property}} = value.get<{{cppType "" $property}}>();
         m_{{$interfaceNameOriginal}}->set{{Camel $property.Name}}({{$property}});
     }
+{{- end }}
 {{- else }}
     // no properties to set {{- /* we generate anyway for consistency */}}
     (void) value;

--- a/templates/module/source/implementation.h.tpl
+++ b/templates/module/source/implementation.h.tpl
@@ -30,9 +30,12 @@ public:
     {{- if $property.Description }}
     /**
     * {{$property.Name}} {{$property.Description}}
+{{- if .IsReadOnly }}
+    * WARNING: This property is read-only and thus can only be set within this implementation, not from the interface.
+{{- end }}
     */
 {{- end }}
-    void set{{Camel $property.Name}}({{ cppParam "" $property}}) override;
+    void set{{Camel $property.Name}}({{ cppParam "" $property}}){{- if not .IsReadOnly }} override{{ end }};
     {{cppTypeRef "" $property}} get{{Camel $property.Name}}() const override;
     {{/*  */ -}}    
 {{- end }}

--- a/templates/module/source/implementation_test.cpp.tpl
+++ b/templates/module/source/implementation_test.cpp.tpl
@@ -28,7 +28,9 @@ TEST_CASE("Testing {{$class}}", "[{{$class}}]"){
 {{- $property := . }}
     SECTION("Test property {{$property.Name}}") {
         // Do implement test here
+        {{- if not .IsReadOnly }}
         test{{$class}}->set{{Camel $property.Name}}({{cppDefault "" $property}});
+        {{- end }}
         REQUIRE( test{{$class}}->get{{Camel $property.Name}}() =={{ if ( eq (cppType "" $property) "float") }} Approx({{- end }} {{cppDefault "" $property}}{{ if ( eq (cppType "" $property) "float")}} ){{- end }} );
     }
 {{- end }}


### PR DESCRIPTION
## 📑 Description
Add support for read-only properties. Remove set from all interfaces, including olink. Only left in implementation

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->