### PR TITLE
fix for olink tests

### DIFF
--- a/goldenmaster/apigear/olink/tests/olink_connection.test.cpp
+++ b/goldenmaster/apigear/olink/tests/olink_connection.test.cpp
@@ -36,17 +36,6 @@ namespace {
         }
         return out;
     }
-    std::vector<Frame> removeAllNonTextMessages(const std::vector<Frame>& in)
-    {
-        auto out = in;
-        if (out.size() > 0)
-        {
-            out.erase(std::remove_if(out.begin(), out.end(),
-                [](const auto& element) { return element.flags != Poco::Net::WebSocket::FRAME_TEXT; }),
-                out.end());
-        }
-        return out;
-    }
 
     int getMessageIndex(const std::vector<Frame>& container, const std::string& payload)
     {
@@ -294,7 +283,7 @@ TEST_CASE("OlinkConnection tests")
         testOlinkConnection->disconnectAndUnlink(sink1Id);
         auto expectedUnlinkMessage = converter.toString(ApiGear::ObjectLink::Protocol::unlinkMessage(sink1Id));
 
-        msgs = removeAllNonTextMessages(server.getReceivedFrames());
+        msgs = removePingMessages(server.getReceivedFrames());
         // Expect socket re-connects, and sends link message on re-connection
         REQUIRE(msgs[0].payload == expectedLinkMessage);
         //Check the unlink message
@@ -347,7 +336,7 @@ TEST_CASE("OlinkConnection tests")
         // wait for re-connection
         Poco::Thread::sleep(501);
         
-        auto msgs = removeAllNonTextMessages(server.getReceivedFrames());
+        auto msgs = removePingMessages(server.getReceivedFrames());
         // Expect socket re-connects, and sends change property messages and link message
         for (auto i = 0; i< 80; i++)
         {

--- a/goldenmaster/apigear/olink/tests/olink_connection.test.cpp
+++ b/goldenmaster/apigear/olink/tests/olink_connection.test.cpp
@@ -143,9 +143,16 @@ TEST_CASE("OlinkConnection tests")
 
         // Send from server init message
         nlohmann::json initProperties = { {"property1", "some_string" }, { "property2",  9 }, { "property3", false } };
-        REQUIRE_CALL(*sink1, olinkOnInit(sink1Id, initProperties, testOlinkConnection->node().get()));
+
+        std::atomic<bool> isInitReceived{ false };
+        auto setInitReceived = [&isInitReceived]() {isInitReceived = true; };
+
+        REQUIRE_CALL(*sink1, olinkOnInit(sink1Id, initProperties, testOlinkConnection->node().get())).SIDE_EFFECT(setInitReceived(););
         auto preparedInitMessage = converter.toString(ApiGear::ObjectLink::Protocol::initMessage(sink1Id, initProperties));
         server.sendFrame(preparedInitMessage);
+        lock.lock();
+        m_messageArrived.wait_for(lock, std::chrono::milliseconds(500), [&isInitReceived]() {return isInitReceived == true; });
+        lock.unlock();
 
         // Stop connection
         REQUIRE_CALL(*sink1, olinkOnRelease());

--- a/goldenmaster/apigear/olink/tests/olinkhost.test.cpp
+++ b/goldenmaster/apigear/olink/tests/olinkhost.test.cpp
@@ -20,6 +20,9 @@
 #include "Poco/Net/HTTPClientSession.h"
 
 #include "nlohmann/json.hpp"
+#include <mutex>
+#include <string>
+#include <condition_variable>
 
 namespace tests{
 
@@ -59,6 +62,9 @@ namespace {
         std::string any_payload = "any";
 
         ApiGear::PocoImpl::OLinkHost testHost(registry, [](auto /*level*/, auto msg){ std::cout << msg << std::endl; });
+        std::condition_variable m_waitForMessageEffects;
+        std::mutex m_waitForMessageEffectsMutex;
+        std::unique_lock<std::mutex> lock(m_waitForMessageEffectsMutex, std::defer_lock);
 
         SECTION("Server creates two nodes for link messages from different sessions for same source and sends back init message. Unlink happens before server closes.")
         {
@@ -78,7 +84,9 @@ namespace {
             clientSocket1.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
             clientSocket2.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
             
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 2; });
+            lock.unlock();
             auto nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 2);
             auto nodeA = nodes[0];
@@ -109,7 +117,9 @@ namespace {
             auto unlinkMessage = converter.toString(ApiGear::ObjectLink::Protocol::unlinkMessage(objectId));
             clientSocket1.sendFrame(unlinkMessage.c_str(), static_cast<int>(unlinkMessage.size()));
             
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 1; });
+            lock.unlock();
             nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 1);
             auto node2 = nodes[0];
@@ -119,7 +129,9 @@ namespace {
 
             REQUIRE_CALL(*source1, olinkUnlinked(objectId));
             clientSocket2.sendFrame(unlinkMessage.c_str(), static_cast<int>(unlinkMessage.size()));
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 0; });
+            lock.unlock();
             nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 0);
             
@@ -145,7 +157,9 @@ namespace {
 
             clientSocket1.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
 
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 1; });
+            lock.unlock();
             auto nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 1);
             REQUIRE(nodes[0].expired() == false);
@@ -159,7 +173,9 @@ namespace {
             }
 
             testHost.close();
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 0; });
+            lock.unlock();
             REQUIRE(registry.getNodes(objectId).size() == 0);
             REQUIRE(registry.getSource(objectId).lock() == source1);
 
@@ -183,7 +199,9 @@ namespace {
 
             clientSocket1.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
 
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 1; });
+            lock.unlock();
             auto nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 1);
             REQUIRE(nodes[0].expired() == false);
@@ -197,7 +215,10 @@ namespace {
             }
             // start test
             registry.removeSource(objectId);
-            Poco::Thread::sleep(100);
+
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 0; });
+            lock.unlock();
 
             REQUIRE(registry.getNodes(objectId).size() == 0);
             REQUIRE(registry.getSource(objectId).expired());
@@ -231,7 +252,9 @@ namespace {
             clientSocket1.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
             clientSocket2.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
 
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 2; });
+            lock.unlock();
             auto nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 2);
             auto nodeA = nodes[0];
@@ -260,7 +283,10 @@ namespace {
             // START TEST
             clientSocket1.sendFrame(any_payload.c_str(), static_cast<int>(any_payload.size()), Poco::Net::WebSocket::FRAME_OP_CLOSE);
             // Send close Frame
-            Poco::Thread::sleep(50);
+
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 1; });
+            lock.unlock();
             nodes = registry.getNodes(objectId);
             // Node 2 still works for source
             REQUIRE(nodes.size() == 1);
@@ -288,7 +314,9 @@ namespace {
             REQUIRE_CALL(*source1, olinkCollectProperties()).RETURN(initProperties1);
             clientSocket1.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
 
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 1; });
+            lock.unlock();
             auto nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 1);
             REQUIRE(!nodes[0].expired());
@@ -305,7 +333,9 @@ namespace {
             clientSocket1.sendFrame(any_payload.c_str(), static_cast<int>(any_payload.size()), Poco::Net::WebSocket::FRAME_OP_CLOSE);
 
             // Send close Frame
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 0; });
+            lock.unlock();
             nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 0);
 
@@ -317,7 +347,9 @@ namespace {
             REQUIRE_CALL(*source1, olinkCollectProperties()).RETURN(initProperties1);
             clientSocket2.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
 
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 1; });
+            lock.unlock();
             nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 1);
             REQUIRE(!nodes[0].expired());

--- a/goldenmaster/apigear/olink/tests/private/test_server/test_server.hpp
+++ b/goldenmaster/apigear/olink/tests/private/test_server/test_server.hpp
@@ -62,19 +62,19 @@ public:
 
 	// Get all the frames received by server since last call of this function.
 	// The frames are cleared from server storage with this call, the only copy is on user side.
+	// Sending a message from a client to server takes some time. Make sure the expected frames are in a buffer with getReceivedFramesNumber.
 	std::vector<Frame> getReceivedFrames()
 	{
-		// Client send frames with some delay, here delay is long enough to make sure all messages are delivered
-		// also due to working in threads.
-		Poco::Thread::sleep(50);
 		std::vector<Frame> frames;
-		std::unique_lock<std::timed_mutex> lock(receivedFramesMutex, std::defer_lock);
-		if (lock.try_lock_for(std::chrono::milliseconds(100)))
-		{
-			std::swap(frames, receivedFrames);
-			lock.unlock();
-		}
+		std::unique_lock<std::timed_mutex> lock(receivedFramesMutex);
+		std::swap(frames, receivedFrames);
 		return frames;
+	}
+
+	uint32_t getReceivedFramesNumber()
+	{
+		std::unique_lock<std::timed_mutex> lock(receivedFramesMutex);
+		return receivedFrames.size();
 	}
 
 	// Implementation of IFrameStorage::storeFrame, 

--- a/goldenmaster/apigear/olink/tests/private/test_server/test_server_request_handler.hpp
+++ b/goldenmaster/apigear/olink/tests/private/test_server/test_server_request_handler.hpp
@@ -45,9 +45,12 @@ public:
 				Frame inFrame;
 				auto receivedSize = socket->receiveFrame(pocobuffer, inFrame.flags);
 				inFrame.payload = std::string(pocobuffer.begin(), receivedSize);
-				m_frameStorage.storeFrame(inFrame);
-				stop = receivedSize == 0 ||
-					(inFrame.flags & Poco::Net::WebSocket::FRAME_OP_BITMASK) == Poco::Net::WebSocket::FRAME_OP_CLOSE;
+				bool isCloseFrame = (inFrame.flags & Poco::Net::WebSocket::FRAME_OP_BITMASK) == Poco::Net::WebSocket::FRAME_OP_CLOSE;
+				if (receivedSize != 0 || isCloseFrame)
+				{
+					m_frameStorage.storeFrame(inFrame);
+				}
+				stop = receivedSize == 0 || isCloseFrame;		
 			} while (!stop);
 			socket.reset();
 		}

--- a/templates/apigear/olink/tests/olink_connection.test.cpp
+++ b/templates/apigear/olink/tests/olink_connection.test.cpp
@@ -36,17 +36,6 @@ namespace {
         }
         return out;
     }
-    std::vector<Frame> removeAllNonTextMessages(const std::vector<Frame>& in)
-    {
-        auto out = in;
-        if (out.size() > 0)
-        {
-            out.erase(std::remove_if(out.begin(), out.end(),
-                [](const auto& element) { return element.flags != Poco::Net::WebSocket::FRAME_TEXT; }),
-                out.end());
-        }
-        return out;
-    }
 
     int getMessageIndex(const std::vector<Frame>& container, const std::string& payload)
     {
@@ -294,7 +283,7 @@ TEST_CASE("OlinkConnection tests")
         testOlinkConnection->disconnectAndUnlink(sink1Id);
         auto expectedUnlinkMessage = converter.toString(ApiGear::ObjectLink::Protocol::unlinkMessage(sink1Id));
 
-        msgs = removeAllNonTextMessages(server.getReceivedFrames());
+        msgs = removePingMessages(server.getReceivedFrames());
         // Expect socket re-connects, and sends link message on re-connection
         REQUIRE(msgs[0].payload == expectedLinkMessage);
         //Check the unlink message
@@ -347,7 +336,7 @@ TEST_CASE("OlinkConnection tests")
         // wait for re-connection
         Poco::Thread::sleep(501);
         
-        auto msgs = removeAllNonTextMessages(server.getReceivedFrames());
+        auto msgs = removePingMessages(server.getReceivedFrames());
         // Expect socket re-connects, and sends change property messages and link message
         for (auto i = 0; i< 80; i++)
         {

--- a/templates/apigear/olink/tests/olink_connection.test.cpp
+++ b/templates/apigear/olink/tests/olink_connection.test.cpp
@@ -143,9 +143,16 @@ TEST_CASE("OlinkConnection tests")
 
         // Send from server init message
         nlohmann::json initProperties = { {"property1", "some_string" }, { "property2",  9 }, { "property3", false } };
-        REQUIRE_CALL(*sink1, olinkOnInit(sink1Id, initProperties, testOlinkConnection->node().get()));
+
+        std::atomic<bool> isInitReceived{ false };
+        auto setInitReceived = [&isInitReceived]() {isInitReceived = true; };
+
+        REQUIRE_CALL(*sink1, olinkOnInit(sink1Id, initProperties, testOlinkConnection->node().get())).SIDE_EFFECT(setInitReceived(););
         auto preparedInitMessage = converter.toString(ApiGear::ObjectLink::Protocol::initMessage(sink1Id, initProperties));
         server.sendFrame(preparedInitMessage);
+        lock.lock();
+        m_messageArrived.wait_for(lock, std::chrono::milliseconds(500), [&isInitReceived]() {return isInitReceived == true; });
+        lock.unlock();
 
         // Stop connection
         REQUIRE_CALL(*sink1, olinkOnRelease());

--- a/templates/apigear/olink/tests/olinkhost.test.cpp
+++ b/templates/apigear/olink/tests/olinkhost.test.cpp
@@ -20,6 +20,9 @@
 #include "Poco/Net/HTTPClientSession.h"
 
 #include "nlohmann/json.hpp"
+#include <mutex>
+#include <string>
+#include <condition_variable>
 
 namespace tests{
 
@@ -59,6 +62,9 @@ namespace {
         std::string any_payload = "any";
 
         ApiGear::PocoImpl::OLinkHost testHost(registry, [](auto /*level*/, auto msg){ std::cout << msg << std::endl; });
+        std::condition_variable m_waitForMessageEffects;
+        std::mutex m_waitForMessageEffectsMutex;
+        std::unique_lock<std::mutex> lock(m_waitForMessageEffectsMutex, std::defer_lock);
 
         SECTION("Server creates two nodes for link messages from different sessions for same source and sends back init message. Unlink happens before server closes.")
         {
@@ -78,7 +84,9 @@ namespace {
             clientSocket1.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
             clientSocket2.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
             
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 2; });
+            lock.unlock();
             auto nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 2);
             auto nodeA = nodes[0];
@@ -109,7 +117,9 @@ namespace {
             auto unlinkMessage = converter.toString(ApiGear::ObjectLink::Protocol::unlinkMessage(objectId));
             clientSocket1.sendFrame(unlinkMessage.c_str(), static_cast<int>(unlinkMessage.size()));
             
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 1; });
+            lock.unlock();
             nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 1);
             auto node2 = nodes[0];
@@ -119,7 +129,9 @@ namespace {
 
             REQUIRE_CALL(*source1, olinkUnlinked(objectId));
             clientSocket2.sendFrame(unlinkMessage.c_str(), static_cast<int>(unlinkMessage.size()));
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 0; });
+            lock.unlock();
             nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 0);
             
@@ -145,7 +157,9 @@ namespace {
 
             clientSocket1.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
 
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 1; });
+            lock.unlock();
             auto nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 1);
             REQUIRE(nodes[0].expired() == false);
@@ -159,7 +173,9 @@ namespace {
             }
 
             testHost.close();
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 0; });
+            lock.unlock();
             REQUIRE(registry.getNodes(objectId).size() == 0);
             REQUIRE(registry.getSource(objectId).lock() == source1);
 
@@ -183,7 +199,9 @@ namespace {
 
             clientSocket1.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
 
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 1; });
+            lock.unlock();
             auto nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 1);
             REQUIRE(nodes[0].expired() == false);
@@ -197,7 +215,10 @@ namespace {
             }
             // start test
             registry.removeSource(objectId);
-            Poco::Thread::sleep(100);
+
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 0; });
+            lock.unlock();
 
             REQUIRE(registry.getNodes(objectId).size() == 0);
             REQUIRE(registry.getSource(objectId).expired());
@@ -231,7 +252,9 @@ namespace {
             clientSocket1.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
             clientSocket2.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
 
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 2; });
+            lock.unlock();
             auto nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 2);
             auto nodeA = nodes[0];
@@ -260,7 +283,10 @@ namespace {
             // START TEST
             clientSocket1.sendFrame(any_payload.c_str(), static_cast<int>(any_payload.size()), Poco::Net::WebSocket::FRAME_OP_CLOSE);
             // Send close Frame
-            Poco::Thread::sleep(50);
+
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 1; });
+            lock.unlock();
             nodes = registry.getNodes(objectId);
             // Node 2 still works for source
             REQUIRE(nodes.size() == 1);
@@ -288,7 +314,9 @@ namespace {
             REQUIRE_CALL(*source1, olinkCollectProperties()).RETURN(initProperties1);
             clientSocket1.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
 
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 1; });
+            lock.unlock();
             auto nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 1);
             REQUIRE(!nodes[0].expired());
@@ -305,7 +333,9 @@ namespace {
             clientSocket1.sendFrame(any_payload.c_str(), static_cast<int>(any_payload.size()), Poco::Net::WebSocket::FRAME_OP_CLOSE);
 
             // Send close Frame
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 0; });
+            lock.unlock();
             nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 0);
 
@@ -317,7 +347,9 @@ namespace {
             REQUIRE_CALL(*source1, olinkCollectProperties()).RETURN(initProperties1);
             clientSocket2.sendFrame(preparedLinkMessage.c_str(), static_cast<int>(preparedLinkMessage.size()));
 
-            Poco::Thread::sleep(50);
+            lock.lock();
+            m_waitForMessageEffects.wait_for(lock, std::chrono::milliseconds(500), [&registry, objectId]() {return registry.getNodes(objectId).size() == 1; });
+            lock.unlock();
             nodes = registry.getNodes(objectId);
             REQUIRE(nodes.size() == 1);
             REQUIRE(!nodes[0].expired());

--- a/templates/apigear/olink/tests/private/test_server/test_server.hpp
+++ b/templates/apigear/olink/tests/private/test_server/test_server.hpp
@@ -62,19 +62,19 @@ public:
 
 	// Get all the frames received by server since last call of this function.
 	// The frames are cleared from server storage with this call, the only copy is on user side.
+	// Sending a message from a client to server takes some time. Make sure the expected frames are in a buffer with getReceivedFramesNumber.
 	std::vector<Frame> getReceivedFrames()
 	{
-		// Client send frames with some delay, here delay is long enough to make sure all messages are delivered
-		// also due to working in threads.
-		Poco::Thread::sleep(50);
 		std::vector<Frame> frames;
-		std::unique_lock<std::timed_mutex> lock(receivedFramesMutex, std::defer_lock);
-		if (lock.try_lock_for(std::chrono::milliseconds(100)))
-		{
-			std::swap(frames, receivedFrames);
-			lock.unlock();
-		}
+		std::unique_lock<std::timed_mutex> lock(receivedFramesMutex);
+		std::swap(frames, receivedFrames);
 		return frames;
+	}
+
+	uint32_t getReceivedFramesNumber()
+	{
+		std::unique_lock<std::timed_mutex> lock(receivedFramesMutex);
+		return receivedFrames.size();
 	}
 
 	// Implementation of IFrameStorage::storeFrame, 

--- a/templates/apigear/olink/tests/private/test_server/test_server_request_handler.hpp
+++ b/templates/apigear/olink/tests/private/test_server/test_server_request_handler.hpp
@@ -45,9 +45,12 @@ public:
 				Frame inFrame;
 				auto receivedSize = socket->receiveFrame(pocobuffer, inFrame.flags);
 				inFrame.payload = std::string(pocobuffer.begin(), receivedSize);
-				m_frameStorage.storeFrame(inFrame);
-				stop = receivedSize == 0 ||
-					(inFrame.flags & Poco::Net::WebSocket::FRAME_OP_BITMASK) == Poco::Net::WebSocket::FRAME_OP_CLOSE;
+				bool isCloseFrame = (inFrame.flags & Poco::Net::WebSocket::FRAME_OP_BITMASK) == Poco::Net::WebSocket::FRAME_OP_CLOSE;
+				if (receivedSize != 0 || isCloseFrame)
+				{
+					m_frameStorage.storeFrame(inFrame);
+				}
+				stop = receivedSize == 0 || isCloseFrame;		
 			} while (!stop);
 			socket.reset();
 		}


### PR DESCRIPTION
PR introduces different way of waiting for messages to be delivered.
Instead of sleep(someInterval) a conditional varaible is used with a condition that checks side effects of delivering the message.

#141 is resolved with this method
#142 is improved, but still not resolved, there are runs on which it doesn't fail but still most of them do

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->