### PR TITLE
fix(apigear): add missing fix for olink tests and disable test for mac

### DIFF
--- a/goldenmaster/apigear/olink/tests/CMakeLists.txt
+++ b/goldenmaster/apigear/olink/tests/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(trompeloeil REQUIRED)
 set(TEST_POCO_OLINK_SOURCES
     test_main.cpp
     olink_connection.test.cpp
-    olinkhost.test.cpp
     olinklogadapter.test.cpp
     test_main.cpp
     private/frame.hpp
@@ -24,6 +23,12 @@ set(TEST_POCO_OLINK_SOURCES
     private/test_server/iframestorage.hpp
     private/test_server/test_server_request_handler.hpp
     )
+
+# do not automatically run this test on MacOS
+# see https://github.com/apigear-io/template-cpp14/issues/142 
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+set(TEST_POCO_OLINK_SOURCES ${TEST_POCO_OLINK_SOURCES} "olinkhost.test.cpp")  
+endif()
 
 add_executable(test_poco_olink ${TEST_POCO_OLINK_SOURCES})
 

--- a/templates/apigear/olink/tests/CMakeLists.txt
+++ b/templates/apigear/olink/tests/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(trompeloeil REQUIRED)
 set(TEST_POCO_OLINK_SOURCES
     test_main.cpp
     olink_connection.test.cpp
-    olinkhost.test.cpp
     olinklogadapter.test.cpp
     test_main.cpp
     private/frame.hpp
@@ -24,6 +23,12 @@ set(TEST_POCO_OLINK_SOURCES
     private/test_server/iframestorage.hpp
     private/test_server/test_server_request_handler.hpp
     )
+
+# do not automatically run this test on MacOS
+# see https://github.com/apigear-io/template-cpp14/issues/142 
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+set(TEST_POCO_OLINK_SOURCES ${TEST_POCO_OLINK_SOURCES} "olinkhost.test.cpp")  
+endif()
 
 add_executable(test_poco_olink ${TEST_POCO_OLINK_SOURCES})
 


### PR DESCRIPTION
Disables test for mac
Improvement: Waiting for init message was made with wait, instead of synchronizing with a conditional variable.
This helps the tests to be more stable for Macos.
This is an improvement for #142 (still unsolved).


<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->